### PR TITLE
Fix update repo methods and clean up session routers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,6 +66,8 @@
         // allow reassignment of param properties
         "no-param-reassign": [2, { "props": false }],
 
-        "import/no-dynamic-require": 0
+        "import/no-dynamic-require": 0,
+
+        "import/extensions": "never"
       }
 }

--- a/src/repos/QuestionsRepo.js
+++ b/src/repos/QuestionsRepo.js
@@ -68,13 +68,15 @@ const updateQuestionById = async (id: number, text: string):
   Promise<?Question> => {
     try {
         const field = {};
-        if (text) field.text = text;
+        if (text !== undefined && text !== null) {
+            field.text = text;
+            await db().createQueryBuilder('questions')
+                .where('questions.id = :questionId')
+                .setParameters({ questionId: id })
+                .update(field)
+                .execute();
+        }
 
-        await db().createQueryBuilder('questions')
-            .where('questions.id = :questionId')
-            .setParameters({ questionId: id })
-            .update(field)
-            .execute();
         return await db().findOneById(id);
     } catch (e) {
         throw new Error(`Problem updating question by id: ${id}`);

--- a/src/repos/SessionsRepo.js
+++ b/src/repos/SessionsRepo.js
@@ -104,19 +104,22 @@ const deleteSessionById = async (id: number) => {
  * Update a session
  * @function
  * @param {number} id - Id of session to update
- * @param {string} [name] - New name of session
+ * @param {string} name - New name of session
  * @return {?Session} Updated session
  */
-const updateSessionById = async (id: number, name: ?string):
+const updateSessionById = async (id: number, name: string):
   Promise<?Session> => {
     try {
         const field = {};
-        if (name) field.name = name;
-        await db().createQueryBuilder('sessions')
-            .where('sessions.id = :sessionId')
-            .setParameters({ sessionId: id })
-            .update(field)
-            .execute();
+        if (name !== undefined && name !== null) {
+            field.name = name;
+            await db().createQueryBuilder('sessions')
+                .where('sessions.id = :sessionId')
+                .setParameters({ sessionId: id })
+                .update(field)
+                .execute();
+        }
+        
         return await db().findOneById(id);
     } catch (e) {
         throw new Error(`Problem updating session by id: ${id}!`);

--- a/src/routers/v2/JoinSessionRouter.js
+++ b/src/routers/v2/JoinSessionRouter.js
@@ -1,0 +1,57 @@
+// @flow
+import { Request } from 'express';
+import AppDevRouter from '../../utils/AppDevRouter';
+import constants from '../../utils/constants';
+import SessionsRepo from '../../repos/SessionsRepo';
+import UsersRepo from '../../repos/UsersRepo';
+import type { APISession } from './APITypes';
+
+class JoinSessionRouter extends AppDevRouter<APISession> {
+    constructor() {
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    getPath(): string {
+        return '/join/session/';
+    }
+
+    async content(req: Request) {
+        const { code } = req.body;
+        let { id } = req.body;
+
+        if (!id && !code) {
+            throw new Error('Session id or code required.');
+        }
+
+        if (code) {
+            id = await SessionsRepo.getSessionId(code);
+            if (!id) {
+                throw new Error(`No session with code ${code} found.`);
+            }
+        }
+
+        const session = await SessionsRepo.getSessionById(id);
+        if (!session) {
+            throw new Error(`No session with id ${id} found.`);
+        }
+
+        const userSessions = await UsersRepo.getSessionsById(req.user.id, 'admin');
+        if (userSessions.filter(Boolean).find(s => session && s.id === session.id)) {
+            throw new Error('Cannot join session you are an admin of');
+        }
+
+        if (!req.app.sessionManager.isLive(code, id)) {
+            await req.app.sessionManager.startNewSession(session);
+        }
+
+        return {
+            node: {
+                id: session.id,
+                name: session.name,
+                code: session.code,
+            },
+        };
+    }
+}
+
+export default new JoinSessionRouter().router;

--- a/src/routers/v2/StartSessionRouter.js
+++ b/src/routers/v2/StartSessionRouter.js
@@ -15,42 +15,17 @@ class StartSessionRouter extends AppDevRouter<APISession> {
     }
 
     async content(req: Request) {
-        const { id, code, create } = req.body;
+        const { code } = req.body;
         let { name } = req.body;
 
         if (!name) name = '';
 
-        if (!(id || code)) {
-            throw new Error('Session id, or code required.');
+        if (!code) {
+            throw new Error('Code required.');
         }
 
-        let session;
-
-        if (id && !create) {
-            session = await SessionsRepo.getSessionById(id);
-        }
-
-        if (code && !create) {
-            const sessionId = await SessionsRepo.getSessionId(code);
-
-            if (sessionId) {
-                session = await SessionsRepo.getSessionById(sessionId);
-            }
-        }
-
-        if (!session) {
-            if (create) {
-                session = await SessionsRepo.createSession(name, code, req.user);
-            } else if (id) {
-                throw new Error(`No session with id ${id} found.`);
-            } else {
-                throw new Error(`No session with code ${code} found.`);
-            }
-        }
-
-        if (!req.app.sessionManager.isLive(code, id)) {
-            await req.app.sessionManager.startNewSession(session);
-        }
+        const session = await SessionsRepo.createSession(name, code, req.user);
+        await req.app.sessionManager.startNewSession(session);
 
         return {
             node: {

--- a/test/repos/draft.test.js
+++ b/test/repos/draft.test.js
@@ -46,9 +46,9 @@ test('Get Drafts from User', async () => {
 });
 
 test('Update Draft', async () => {
-    const newDraft = await DraftsRepo.updateDraft(draft1.id, 'New Question', undefined);
+    const newDraft = await DraftsRepo.updateDraft(draft1.id, 'New Question', ['hi']);
     expect(newDraft.text).toBe('New Question');
-    expect(newDraft.options).toEqual(draft1.options);
+    expect(newDraft.options).toEqual(['hi']);
     expect(newDraft.id).toBe(draft1.id);
     draft1 = newDraft;
 });

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -45,7 +45,7 @@ test('Get Polls from Session', async () => {
 test('Update Poll', async () => {
     const poll = await PollsRepo.updatePollById(id, 'New Poll', null, false);
     expect(poll.text).toBe('New Poll');
-    expect(poll.canShare).toBeFalsy();
+    expect(poll.shared).toBe(false);
 });
 
 test('Get Shared Polls from Session', async () => {
@@ -62,7 +62,7 @@ test('Get Polls from Session', async () => {
     const poll = await PollsRepo
         .createPoll('Another poll', session, {}, true, 'FREE_RESPONSE');
     const polls = await SessionsRepo.getPolls(session.id);
-    expect(polls.length > 1).toBeTruthy();
+    expect(polls.length > 1).toBe(true);
     expect(polls[1].id).toBe(poll.id);
     expect(polls[0].id).toBe(id);
 });

--- a/test/repos/question.test.js
+++ b/test/repos/question.test.js
@@ -64,9 +64,9 @@ test('Get Session From Both Questions', async () => {
 
 test('Verify Ownership', async () => {
     const tempUser = await UsersRepo.createDummyUser('wastemon');
-    expect(await QuestionsRepo.isOwnerById(question1.id, user)).toBeTruthy();
-    expect(await QuestionsRepo.isOwnerById(question2.id, user)).toBeTruthy();
-    expect(await QuestionsRepo.isOwnerById(question1.id, tempUser)).toBeFalsy();
+    expect(await QuestionsRepo.isOwnerById(question1.id, user)).toBe(true);
+    expect(await QuestionsRepo.isOwnerById(question2.id, user)).toBe(true);
+    expect(await QuestionsRepo.isOwnerById(question1.id, tempUser)).toBe(false);
     await UsersRepo.deleteUserById(tempUser.id);
 });
 

--- a/test/repos/userSession.test.js
+++ b/test/repos/userSession.test.js
@@ -19,7 +19,7 @@ beforeAll(async () => {
 test('Create Session', async () => {
     const session = await UserSessionsRepo.createOrUpdateSession(user, 'access', 'refresh');
     sessionId = session.id;
-    expect(session.isActive).toBeTruthy();
+    expect(session.isActive).toBe(true);
     expect(session.sessionToken).toBe('access');
     expect(session.updateToken).toBe('refresh');
 });
@@ -33,16 +33,16 @@ test('Get User From Token', async () => {
 
 test('Verify session', async () => {
     const valid = await UserSessionsRepo.verifySession('access');
-    expect(valid).toBeTruthy();
+    expect(valid).toBe(true);
     const invalid = await UserSessionsRepo.verifySession('invalid');
-    expect(invalid).toBeFalsy();
+    expect(invalid).toBe(false);
 });
 
 test('Update session', async () => {
     const nullObj = await UserSessionsRepo.updateSession('invalid');
     expect(nullObj).toBeNull();
     const obj = await UserSessionsRepo.updateSession('refresh');
-    expect(obj.isActive).toBeTruthy();
+    expect(obj.isActive).toBe(true);
 });
 
 // Teardown

--- a/test/routes/api.draft.test.js
+++ b/test/routes/api.draft.test.js
@@ -31,7 +31,7 @@ test('Create a draft', async () => {
     const getstr = await request(post('/drafts/', body, userToken));
     const getres = getstr;
     draft1 = getres.data.node;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(draft1).toMatchObject(body);
 });
 
@@ -39,7 +39,7 @@ test('Get drafts (Authorized)', async () => {
     const getstr = await request(get('/drafts/', userToken));
     const getres = getstr;
     const { edges } = getres.data;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(edges.length).toBe(1);
     expect(edges[0].node).toMatchObject(draft1);
 });
@@ -47,7 +47,7 @@ test('Get drafts (Authorized)', async () => {
 test('Get drafts (Unauthorized)', async () => {
     const getstr = await request(get('/drafts/', 'blah'));
     const getres = getstr;
-    expect(getres.success).toBeFalsy();
+    expect(getres.success).toBe(false);
 });
 
 test('Update a draft', async () => {
@@ -57,7 +57,7 @@ test('Update a draft', async () => {
     const getstr = await request(put(`/drafts/${draft1.id}`, body, userToken));
     const getres = getstr;
     const { node } = getres.data;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(node.text).toBe(body.text);
     expect(node.options).toMatchObject(draft1.options);
     expect(node.id).toBe(draft1.id);
@@ -72,7 +72,7 @@ test('Create another draft', async () => {
     const getstr = await request(post('/drafts/', body, userToken));
     const getres = getstr;
     draft2 = getres.data.node;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(draft2).toMatchObject(body);
 });
 
@@ -80,7 +80,7 @@ test('Get updated list of drafts (Authorized)', async () => {
     const getstr = await request(get('/drafts/', userToken));
     const getres = getstr;
     const { edges } = getres.data;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(edges.length).toBe(2);
     expect(edges[0].node).toMatchObject(draft1);
     expect(edges[1].node).toMatchObject(draft2);
@@ -88,9 +88,9 @@ test('Get updated list of drafts (Authorized)', async () => {
 
 test('Delete draft', async () => {
     let result = await request(del(`/drafts/${draft1.id}`, userToken));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
     result = await request(del(`/drafts/${draft2.id}`, userToken));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 afterAll(async () => {

--- a/test/routes/api.poll.test.js
+++ b/test/routes/api.poll.test.js
@@ -31,33 +31,33 @@ beforeAll(async () => {
     const opts = { name: 'Test session', code: SessionsRepo.createCode() };
     const result = await request(post('/sessions/', opts, token));
     session = result.data.node;
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 test('create poll', async () => {
     const opts = { text: 'Poll text', shared: true, type: 'MULTIPLE_CHOICE' };
     const result = await request(post(`/sessions/${session.id}/polls`, opts, token));
     poll = result.data.node;
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 test('create poll with invalid token', async () => {
     const opts = { text: 'Poll text', results: {}, shared: true };
     const result = await request(post(`/sessions/${session.id}/polls`, opts, 'invalid'));
-    expect(result.success).toBeFalsy();
+    expect(result.success).toBe(false);
 });
 
 test('get poll by id', async () => {
     const getstr = await request(get(`/polls/${poll.id}`, token));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(poll.id).toBe(getres.data.node.id);
 });
 
 test('get polls by session', async () => {
     const getstr = await request(get(`/sessions/${session.id}/polls`, token));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(poll.id).toBe(getres.data.edges[0].node.id);
 });
 
@@ -69,7 +69,7 @@ test('update poll', async () => {
     };
     const getstr = await request(put(`/polls/${poll.id}`, opts, token));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(getres.data.node.text).toBe('Updated text');
     expect(getres.data.node.results).toMatchObject({ A: 1 });
 });
@@ -81,22 +81,22 @@ test('update poll with invalid token', async () => {
     };
     const getstr = await request(put(`/polls/${poll.id}`, opts, 'invalid'));
     const getres = getstr;
-    expect(getres.success).toBeFalsy();
+    expect(getres.success).toBe(false);
 });
 
 test('delete poll with invalid token', async () => {
     const result = await request(del(`/polls/${poll.id}`, 'invalid'));
-    expect(result.success).toBeFalsy();
+    expect(result.success).toBe(false);
 });
 
 test('delete poll', async () => {
     const result = await request(del(`/polls/${poll.id}`, token));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 afterAll(async () => {
     const result = await request(del(`/sessions/${session.id}`, token));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
     await UsersRepo.deleteUserById(userId);
     await UserSessionsRepo.deleteSession(session.id);
     console.log('Passed all poll route tests');

--- a/test/routes/api.question.test.js
+++ b/test/routes/api.question.test.js
@@ -28,7 +28,7 @@ beforeAll(async () => {
     const opts = { name: 'Test session', code: SessionsRepo.createCode() };
     const result = await request(post('/sessions/', opts, adminToken));
     session = result.data.node;
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 
     await SessionsRepo.addUsersByGoogleIds(session.id, ['member'], 'member');
 });
@@ -39,7 +39,7 @@ test('create question', async () => {
     };
     const result = await request(post(`/sessions/${session.id}/questions`, opts, memberToken));
     question = result.data.node;
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 test('create question with invalid token', async () => {
@@ -47,20 +47,20 @@ test('create question with invalid token', async () => {
         text: 'Why do we have to test shit? (PG-13)',
     };
     const result = await request(post(`/sessions/${session.id}/questions`, opts, adminToken));
-    expect(result.success).toBeFalsy();
+    expect(result.success).toBe(false);
 });
 
 test('get question by id', async () => {
     const getstr = await request(get(`/questions/${question.id}`, memberToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(question.id).toBe(getres.data.node.id);
 });
 
 test('get questions by session', async () => {
     const getstr = await request(get(`/sessions/${session.id}/questions`, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(question.id).toBe(getres.data.edges[0].node.id);
 });
 
@@ -70,7 +70,7 @@ test('update question', async () => {
     };
     const getstr = await request(put(`/questions/${question.id}`, opts, memberToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(getres.data.node.text).toBe('Why do we have to test stuff? (PG)');
     expect(getres.data.node.id).toBe(question.id);
 });
@@ -81,17 +81,17 @@ test('update question with invalid token', async () => {
     };
     const getstr = await request(put(`/questions/${question.id}`, opts, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeFalsy();
+    expect(getres.success).toBe(false);
 });
 
 test('delete question', async () => {
     const result = await request(del(`/questions/${question.id}`, memberToken));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 afterAll(async () => {
     const result = await request(del(`/sessions/${session.id}`, adminToken));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
     await UsersRepo.deleteUserById(admin.id);
     await UsersRepo.deleteUserById(member.id);
     await UserSessionsRepo.deleteSession(session.id);

--- a/test/routes/api.session.test.js
+++ b/test/routes/api.session.test.js
@@ -37,20 +37,20 @@ test('create session', async () => {
     const option = post('/sessions/', opts, adminToken);
     const result = await request(option);
     sessionres = result;
-    expect(sessionres.success).toBeTruthy();
+    expect(sessionres.success).toBe(true);
 });
 
 test('get single session', async () => {
     const getstr = await request(get(`/sessions/${sessionres.data.node.id}`, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(sessionres).toMatchObject(getres);
 });
 
 test('get sessions for admin', async () => {
     const getstr = await request(get('/sessions/all/admin', adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(sessionres.data).toMatchObject(getres.data[0]);
 });
 
@@ -63,13 +63,13 @@ test('add admins to session', async () => {
     const getstr = await request(post(`/sessions/${sessionres.data.node.id}/admins/`, body,
         adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
 });
 
 test('get admins for session', async () => {
     const getstr = await request(get(`/sessions/${sessionres.data.node.id}/admins/`, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     const { edges } = getres.data;
     expect(edges.length).toBe(2);
     expect(edges[0].node.id).toBe(adminId);
@@ -83,7 +83,7 @@ test('remove admin from session', async () => {
     const getstr = await request(put(`/sessions/${sessionres.data.node.id}/admins/`, body,
         adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     UsersRepo.deleteUserById(userId);
 });
 
@@ -97,20 +97,20 @@ test('add members to session', async () => {
     const getstr = await request(post(`/sessions/${sessionres.data.node.id}/members/`, body,
         adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
 });
 
 test('get sessions as member', async () => {
     const getstr = await request(get('/sessions/all/member/', userToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(sessionres.data).toMatchObject(getres.data[0]);
 });
 
 test('get members of session', async () => {
     const getstr = await request(get(`/sessions/${sessionres.data.node.id}/members/`, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     const { edges } = getres.data;
     expect(edges.length).toBe(1);
     expect(edges[0].node.id).toBe(userId);
@@ -123,38 +123,38 @@ test('remove member from session', async () => {
     const getstr = await request(put(`/sessions/${sessionres.data.node.id}/members`, body,
         adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     await UsersRepo.deleteUserById(userId);
 });
 
 test('get sessions for admin', async () => {
     const getstr = await request(get('/sessions/all/admin/', adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(getres.data[0]).toMatchObject(sessionres.data);
 });
 
 test('update session', async () => {
     const getstr = await request(put(`/sessions/${sessionres.data.node.id}`, opts2, adminToken));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(getres.data.node.name).toBe('New session');
 });
 
 test('update session with invalid adminToken', async () => {
     const getstr = await request(put(`/sessions/${sessionres.data.node.id}`, opts2, 'invalid'));
     const getres = getstr;
-    expect(getres.success).toBeFalsy();
+    expect(getres.success).toBe(false);
 });
 
 test('delete session with invalid adminToken', async () => {
     const result = await request(del(`/sessions/${sessionres.data.node.id}`, 'invalid'));
-    expect(result.success).toBeFalsy();
+    expect(result.success).toBe(false);
 });
 
 test('delete session', async () => {
     const result = await request(del(`/sessions/${sessionres.data.node.id}`, adminToken));
-    expect(result.success).toBeTruthy();
+    expect(result.success).toBe(true);
 });
 
 afterAll(async () => {

--- a/test/routes/api.user.test.js
+++ b/test/routes/api.user.test.js
@@ -26,7 +26,7 @@ beforeAll(async () => {
 test('get user', async () => {
     const getstr = await request(get('/users/', token));
     const getres = getstr;
-    expect(getres.success).toBeTruthy();
+    expect(getres.success).toBe(true);
     expect(user.id).toBe(getres.data.id);
     expect(user.netId).toBe(getres.data.netId);
 });


### PR DESCRIPTION
- Fixed update methods since typeorm's update function didn't support updating JSON or array fields 
- Split up /start/session/ route which was originally for creating or joining a session into /start/session/ (for creating) and /join/session/ (for joining) to make logic more clear
- Small Jest tweak cause noticed that .toBeTruthy and .toBeFalsy isn't equivalent to .toBe(true) and .toBe(false)