### PR TITLE
Fix error when admin was joining polls

### DIFF
--- a/src/routers/v2/JoinSessionRouter.js
+++ b/src/routers/v2/JoinSessionRouter.js
@@ -3,7 +3,6 @@ import { Request } from 'express';
 import AppDevRouter from '../../utils/AppDevRouter';
 import constants from '../../utils/Constants';
 import SessionsRepo from '../../repos/SessionsRepo';
-import UsersRepo from '../../repos/UsersRepo';
 import type { APISession } from './APITypes';
 
 class JoinSessionRouter extends AppDevRouter<APISession> {
@@ -33,11 +32,6 @@ class JoinSessionRouter extends AppDevRouter<APISession> {
         const session = await SessionsRepo.getSessionById(id);
         if (!session) {
             throw new Error(`No session with id ${id} found.`);
-        }
-
-        const userSessions = await UsersRepo.getSessionsById(req.user.id, 'admin');
-        if (userSessions.filter(Boolean).find(s => session && s.id === session.id)) {
-            throw new Error('Cannot join session you are an admin of');
         }
 
         if (!req.app.sessionManager.isLive(code, id)) {


### PR DESCRIPTION
Admins can use the JoinSessionRouter since this route allows everyone to connect to the session socket