### PR TITLE
Fix live session indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7735,10 +7735,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.15.3",
     "globby": "^6.1.0",
     "google-auth-library": "^2.0.0",
+    "merge": "^1.2.1",
     "mysql": "^2.13.0",
     "passport": "^0.4.0",
     "passport-google-oauth20": "^1.0.0",

--- a/src/SessionManager.js
+++ b/src/SessionManager.js
@@ -83,17 +83,28 @@ class SessionManager {
   }
 
   /**
+   * Find the session's socket
+   * @function
+   * @param {string} [sessionCode] - Code of session to find
+   * @param {number} [id] - ID of sesssion to find
+   * @return {socket} Socket of the session
+   */
+  findSocket(sessionCode: ?string, id: ?number): SocketIO.socket {
+      return this.sessionSockets.find((x) => {
+          if (x && x.session) return x.session.code === sessionCode || x.session.id === id;
+          return false;
+      });
+  }
+
+  /**
    * Determines if a session is live
    * @function
    * @param {string} [sessionCode] - Code of session to check
-   * @param {number} [id] - Id of sesssion to check
+   * @param {number} [id] - ID of sesssion to check
    * @return {boolean} Whether the session is live
    */
   isLive(sessionCode: ?string, id: ?number): boolean {
-      const socket = this.sessionSockets.find((x) => {
-          const isSession = x && x.session;
-          return isSession ? x.session.code === sessionCode || x.session.id === id : false;
-      });
+      const socket = this.findSocket(sessionCode, id);
       return socket !== undefined ? socket.isLive : false;
   }
 }

--- a/src/routers/v2/JoinSessionRouter.js
+++ b/src/routers/v2/JoinSessionRouter.js
@@ -34,7 +34,7 @@ class JoinSessionRouter extends AppDevRouter<APISession> {
             throw new Error(`No session with id ${id} found.`);
         }
 
-        if (!req.app.sessionManager.isLive(code, id)) {
+        if (req.app.sessionManager.findSocket(code, id) === undefined) {
             await req.app.sessionManager.startNewSession(session);
         }
 


### PR DESCRIPTION
Initial implementation of live-session indicator caused weird behavior in `/join/session/` route, so fixed it by separating the functionality of verifying the existence and activeness of session socket.