### PR TITLE
Return empty array if no polls match group ID

### DIFF
--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -42,7 +42,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object> {
                 pollsByDate.polls = [p];
             }
         });
-        return [pollsByDate];
+        return Object.keys(pollsByDate).length === 0 ? [] : [pollsByDate];
     }
 }
 


### PR DESCRIPTION
`/sessions/:id/polls/` will return `[]` instead of `[{}]` if no polls found