### PR TITLE
Change DB port to rely on env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create a .env file in the repository with the following contents:
 export DB_HOST=localhost
 export DB_USERNAME=FILL_IN
 export DB_PASSWORD=FILL_IN
+export DB_PORT=5432
 export DB_NAME=pollo
 export GOOGLE_CLIENT_ID=FILL_IN
 export GOOGLE_CLIENT_SECRET=FILL_IN

--- a/src/db/DbConnection.js
+++ b/src/db/DbConnection.js
@@ -16,11 +16,12 @@ import User from '../models/User';
 import UserSession from '../models/UserSession';
 
 dotenv.config(); // establish env variables
+const isProduction = process.env.NODE_ENV === 'production';
 
 const driver = {
     type: 'postgres',
     host: process.env.DB_HOST,
-    port: 5432,
+    port: isProduction ? process.env.DB_PORT : 5432,
     username: process.env.DB_USERNAME,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
@@ -35,8 +36,6 @@ const entities = [
     User,
     UserSession,
 ];
-
-const isProduction = process.env.NODE_ENV === 'production';
 
 // Setup options
 const connectionOptions: ConnectionOptions = {


### PR DESCRIPTION
The new DBs on DigitalOcean don't use port 5432 so we can use an env var in production to specify it.