### PR TITLE
Add deploy hooks for dev server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,19 @@ before_install:
 - openssl aes-256-cbc -K $encrypted_b9db1102fcfa_key -iv $encrypted_b9db1102fcfa_iv
   -in server.pem.enc -out server.pem -d
 - psql --host=localhost -c 'CREATE DATABASE clicker;' -U postgres
+jobs:
+  include:
+  - if: branch = master
+    env:
+    - NODE_IMAGE="pollo-dev"
+    - DOMAIN="pollo-dev.cornellappdev.com"
+  - if: branch = release
+    env:
+    - NODE_IMAGE="pollo"
+    - DOMAIN="pollo-backend.cornellappdev.com"
 env:
   global:
-  - CHRONICLE_ACCESS_KEY='' CHRONICLE_SECRET_KEY='' DB_HOST='localhost' DB_USERNAME='postgres'
+  - DB_HOST='localhost' DB_USERNAME='postgres'
     DB_PASSWORD='' DB_NAME='clicker' GOOGLE_CLIENT_ID='?' GOOGLE_CLIENT_SECRET='?'
     GOOGLE_REDIRECT_URI='?'
   - secure: yAz3UYvG7LnrYppyGMQxg2MuJWuhO0uKIrfhklAryDYIVZhkI+saMCO9fcFBGp65uLlme6n/dKXmpd0kTk57IRd5XrzXBab95CmyO/BcaWu52TxcsE3+NTdCDXB2YVzozplXAWN8gr3XohoXHLf0oKFdqU3EntZ8OvamH/5fPpJAuZ9cE2LYsb/y9y/QlTQ6+YrK9FuzncK++lvMRvZkoeJEwUrWLPY/upaGJJNS7HoB9hMNgxJ81ls5ytAgyGBc5RZJk+eXfmQ9KdLzSrc98FKwKHZBQ2MkTFg4bTGhS235Clmqy4WYdUD2EgHdxhz5erTQNynTxqhPuNFKiMltXUs9Wu4BKTC03vwMBbvXFe2OgMfXVDTHLij4sGCfJxKhXcrfFEmNcFWFXynrXxRMD6sWtR/xDJMPYNt63Av8uKboEYnAtMlQEtFl4Mi6GeuA2xU0GTX5KwKy1HWxoi00ElYzsk0bvyKP7dyfNqpPn1G1GfDiVkj8Db+/a3PfhOYsPtzPLgkthWQSKaB/2e+zT+NmjFUwiVSj4ppL1qznvj9JDzrW9cK7mioEPtVMOHVGDMymEoOUbi16Tn34DyKabavdvYFEALtndUPPKAbK4M3x+MOIAzjLHw4vM8LvWxQ8ie8XtuNLXVLMD8zs6uE/zkPMIZi4wSNxz4iNkrhgfmQ=
@@ -25,6 +35,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: release
+    branch: master
 script:
 - npm run start &
 - sleep 10; npm run test

--- a/docker_push
+++ b/docker_push
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build -t cornellappdev/pollo:"$TRAVIS_COMMIT" --no-cache .
-docker push cornellappdev/pollo:"$TRAVIS_COMMIT"
+docker build -t cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT" --no-cache .
+docker push cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"
 chmod 600 server.pem
-ssh -i server.pem appdev@pollo-backend.cornellappdev.com "cd docker-compose; export IMAGE_TAG='$TRAVIS_COMMIT'; 
+ssh -i server.pem appdev@"$DOMAIN" "cd docker-compose; export IMAGE_TAG='$TRAVIS_COMMIT'; 
     docker stack deploy --compose-file docker-compose.yml the-stack"


### PR DESCRIPTION
- Builds docker image and updates server by sshing into the dev server every time a commit is pushed to `master` (unless we want to use a dev branch or something)

Tested it on this branch. Output can be seen here:
https://travis-ci.org/cuappdev/pollo-backend/builds/495646469