### PR TITLE
Add a v2 route to refresh token

### DIFF
--- a/src/API.js
+++ b/src/API.js
@@ -79,6 +79,10 @@ class API {
           const r = { success: true, data: req.session };
           res.json(r);
       });
+      this.express.post('/api/v2/auth/refresh', lib.updateSession, (req, res) => {
+          const r = { success: true, data: req.session };
+          res.json(r);
+      });
       this.express.get('/error',
           (req, res) => res.send('Error authenticating'));
       this.express.post('/api/v2/auth/mobile', async (req, res) => {


### PR DESCRIPTION
@AAAstorga wanted `/auth/refresh` route to have `api/v2/` path in front

@meganle Not sure if I could delete the original `/auth/refresh` so I just created a new route. Thoughts on whether we should keep the old one?