### PR TITLE
Implement custom middleware and rewrite auth routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,11 +1999,6 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
-    "bignumber.js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg=="
-    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -2789,7 +2784,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.4",
@@ -6808,7 +6804,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -8407,38 +8404,6 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
-    "mysql": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.15.0.tgz",
-      "integrity": "sha512-C7tjzWtbN5nzkLIV+E8Crnl9bFyc7d3XJcBAvHKEVkjrYjogz3llo22q6s/hw+UcsE4/844pDob9ac+3dVjQSA==",
-      "requires": {
-        "bignumber.js": "4.0.4",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "sqlstring": "2.3.0"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
-    },
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
@@ -8645,11 +8610,6 @@
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
       "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
-    },
-    "oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -9107,69 +9067,6 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
-    "passport": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
-      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
-      "requires": {
-        "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
-      }
-    },
-    "passport-google-oauth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth/-/passport-google-oauth-1.0.0.tgz",
-      "integrity": "sha1-ZfUGMxkq0GJ6GLCJYAdxCdhOt20=",
-      "dev": true,
-      "requires": {
-        "passport-google-oauth1": "1.x.x",
-        "passport-google-oauth20": "1.x.x"
-      }
-    },
-    "passport-google-oauth1": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth1/-/passport-google-oauth1-1.0.0.tgz",
-      "integrity": "sha1-r3SoA99R7GRvZqRNgigr5vEI4Mw=",
-      "dev": true,
-      "requires": {
-        "passport-oauth1": "1.x.x"
-      }
-    },
-    "passport-google-oauth20": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-1.0.0.tgz",
-      "integrity": "sha1-O5YOih1w0dvnlGFcgnxoxAOSpdA=",
-      "requires": {
-        "passport-oauth2": "1.x.x"
-      }
-    },
-    "passport-oauth1": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
-      "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
-      "dev": true,
-      "requires": {
-        "oauth": "0.9.x",
-        "passport-strategy": "1.x.x",
-        "utils-merge": "1.x.x"
-      }
-    },
-    "passport-oauth2": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
-      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
-      "requires": {
-        "oauth": "0.9.x",
-        "passport-strategy": "1.x.x",
-        "uid2": "0.0.x",
-        "utils-merge": "1.x.x"
-      }
-    },
-    "passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
-    },
     "path-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -9247,11 +9144,6 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
-    },
-    "pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pbkdf2": {
       "version": "3.0.14",
@@ -10976,11 +10868,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sqlstring": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.0.tgz",
-      "integrity": "sha1-UluKT9Jtb3GqYegipsr5dtMa0qg="
-    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
@@ -11227,6 +11114,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -12079,11 +11967,6 @@
         "webpack-sources": "^1.0.1"
       }
     },
-    "uid2": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -12363,7 +12246,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "flow-bin": "^0.50.0",
     "form-urlencoded": "^2.0.4",
     "jest": "^21.2.1",
-    "passport-google-oauth": "^1.0.0",
     "request-promise-native": "^1.0.5",
     "serve-favicon": "^2.4.3",
     "webpack": "^3.3.0"
@@ -58,9 +57,6 @@
     "globby": "^6.1.0",
     "google-auth-library": "^2.0.0",
     "merge": "^1.2.1",
-    "mysql": "^2.13.0",
-    "passport": "^0.4.0",
-    "passport-google-oauth20": "^1.0.0",
     "pg": "^7.4.1",
     "reflect-metadata": "^0.1.12",
     "socket.io": "^2.0.3",

--- a/src/routers/v1/EndPollRouter.js
+++ b/src/routers/v1/EndPollRouter.js
@@ -10,7 +10,7 @@ class EndPollRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/EndPollRouter.js
+++ b/src/routers/v1/EndPollRouter.js
@@ -6,7 +6,11 @@ import GroupsRepo from '../../repos/GroupsRepo';
 
 class EndPollRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.POST, false);
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/GenerateCodeRouter.js
+++ b/src/routers/v1/GenerateCodeRouter.js
@@ -6,7 +6,11 @@ import constants from '../../utils/Constants';
 
 class GenerateCodeRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.GET, false);
+        super(constants.REQUEST_TYPES.GET);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/GenerateCodeRouter.js
+++ b/src/routers/v1/GenerateCodeRouter.js
@@ -10,7 +10,7 @@ class GenerateCodeRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/HelloWorldRouter.js
+++ b/src/routers/v1/HelloWorldRouter.js
@@ -5,7 +5,11 @@ import constants from '../../utils/Constants';
 
 class HelloWorldRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.GET, false);
+        super(constants.REQUEST_TYPES.GET);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/HelloWorldRouter.js
+++ b/src/routers/v1/HelloWorldRouter.js
@@ -9,7 +9,7 @@ class HelloWorldRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/DeletePollRouter.js
+++ b/src/routers/v1/Polls/DeletePollRouter.js
@@ -10,7 +10,7 @@ class DeletePollRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/DeletePollRouter.js
+++ b/src/routers/v1/Polls/DeletePollRouter.js
@@ -6,7 +6,11 @@ import constants from '../../../utils/Constants';
 
 class DeletePollRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.DELETE, false);
+        super(constants.REQUEST_TYPES.DELETE);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/GetLivePollsRouter.js
+++ b/src/routers/v1/Polls/GetLivePollsRouter.js
@@ -5,7 +5,11 @@ import constants from '../../../utils/Constants';
 
 class GetLivePollsRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.POST, false);
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/GetLivePollsRouter.js
+++ b/src/routers/v1/Polls/GetLivePollsRouter.js
@@ -9,7 +9,7 @@ class GetLivePollsRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/GetPollRouter.js
+++ b/src/routers/v1/Polls/GetPollRouter.js
@@ -6,7 +6,7 @@ import type { APIPoll } from '../APITypes';
 
 class GetPollRouter extends AppDevNodeRouter<APIPoll> {
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/GetPollRouter.js
+++ b/src/routers/v1/Polls/GetPollRouter.js
@@ -5,8 +5,8 @@ import GroupsRepo from '../../../repos/GroupsRepo';
 import type { APIPoll } from '../APITypes';
 
 class GetPollRouter extends AppDevNodeRouter<APIPoll> {
-    constructor() {
-        super(false);
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/PostPollRouter.js
+++ b/src/routers/v1/Polls/PostPollRouter.js
@@ -9,7 +9,11 @@ import type { APIPoll } from '../APITypes';
 
 class PostPollRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.POST, false);
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/PostPollRouter.js
+++ b/src/routers/v1/Polls/PostPollRouter.js
@@ -13,7 +13,7 @@ class PostPollRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/UpdatePollRouter.js
+++ b/src/routers/v1/Polls/UpdatePollRouter.js
@@ -8,7 +8,11 @@ import type { APIPoll } from '../APITypes';
 
 class UpdatePollRouter extends AppDevRouter<Object> {
     constructor() {
-        super(constants.REQUEST_TYPES.PUT, false);
+        super(constants.REQUEST_TYPES.PUT);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/Polls/UpdatePollRouter.js
+++ b/src/routers/v1/Polls/UpdatePollRouter.js
@@ -12,7 +12,7 @@ class UpdatePollRouter extends AppDevRouter<Object> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v1/StartPollRouter.js
+++ b/src/routers/v1/StartPollRouter.js
@@ -7,7 +7,11 @@ import type { APIPoll } from './APITypes';
 
 class StartPollRouter extends AppDevRouter<APIPoll> {
     constructor() {
-        super(constants.REQUEST_TYPES.POST, false);
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    middleware() {
+        return (req, res, next) => next();
     }
 
     getPath(): string {

--- a/src/routers/v1/StartPollRouter.js
+++ b/src/routers/v1/StartPollRouter.js
@@ -11,7 +11,7 @@ class StartPollRouter extends AppDevRouter<APIPoll> {
     }
 
     middleware() {
-        return (req, res, next) => next();
+        return [];
     }
 
     getPath(): string {

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -29,7 +29,8 @@ export type APIPoll = {|
   results: Object,
   shared: boolean,
   type: string,
-  answer: ?string
+  answer: ?string,
+  correctAnswer: string
 |}
 
 export type APIDraft = {|

--- a/src/routers/v2/Users/InitializeSessionRouter.js
+++ b/src/routers/v2/Users/InitializeSessionRouter.js
@@ -1,0 +1,37 @@
+// @flow
+import { Request } from 'express';
+import { OAuth2Client } from 'google-auth-library';
+import AppDevRouter from '../../../utils/AppDevRouter';
+import constants from '../../../utils/Constants';
+import LogUtils from '../../../utils/LogUtils';
+import UserSessionsRepo from '../../../repos/UserSessionsRepo';
+
+class InitializeSessionRouter extends AppDevRouter<Object> {
+    constructor() {
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    getPath(): string {
+        return '/auth/mobile/';
+    }
+
+    middleware() {
+        return [];
+    }
+
+    async content(req: Request) {
+        const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
+
+        return client
+            .verifyIdToken({
+                idToken: req.body.idToken,
+                aud: process.env.GOOGLE_CLIENT_ID, // audience
+            })
+            .then(login => UserSessionsRepo.createUserAndInitializeSession(login))
+            .catch((error) => {
+                LogUtils.logErr(error, null, 'Error authenticating');
+            });
+    }
+}
+
+export default new InitializeSessionRouter().router;

--- a/src/routers/v2/Users/RefreshSessionRouter.js
+++ b/src/routers/v2/Users/RefreshSessionRouter.js
@@ -1,0 +1,25 @@
+// @flow
+import { Request } from 'express';
+import AppDevRouter from '../../../utils/AppDevRouter';
+import constants from '../../../utils/Constants';
+import lib from '../../../utils/Lib';
+
+class RefreshTokenRouter extends AppDevRouter<Object> {
+    constructor() {
+        super(constants.REQUEST_TYPES.POST);
+    }
+
+    getPath(): string {
+        return '/auth/refresh/';
+    }
+
+    middleware() {
+        return [lib.updateSession];
+    }
+
+    async content(req: Request) {
+        return req.session;
+    }
+}
+
+export default new RefreshTokenRouter().router;

--- a/src/utils/AppDevNodeRouter.js
+++ b/src/utils/AppDevNodeRouter.js
@@ -12,8 +12,8 @@ export type AppDevNodeResponse<T> = { node: T }
  * NOTE: Expects the path to contain an :id field!
  */
 class AppDevNodeRouter<T> extends AppDevRouter<AppDevNodeResponse<T>> {
-    constructor(auth: ?boolean) {
-        super('GET', auth);
+    constructor() {
+        super('GET');
     }
 
     async fetchWithID(givenID: id, req: Request): Promise<?T> {

--- a/src/utils/AppDevNodeRouter.js
+++ b/src/utils/AppDevNodeRouter.js
@@ -1,6 +1,7 @@
 // @flow
 import { Request } from 'express';
 import AppDevRouter from './AppDevRouter';
+import constants from './Constants';
 import LogUtils from './LogUtils';
 
 type id = number
@@ -13,7 +14,7 @@ export type AppDevNodeResponse<T> = { node: T }
  */
 class AppDevNodeRouter<T> extends AppDevRouter<AppDevNodeResponse<T>> {
     constructor() {
-        super('GET');
+        super(constants.REQUEST_TYPES.GET);
     }
 
     async fetchWithID(givenID: id, req: Request): Promise<?T> {

--- a/src/utils/AppDevRouter.js
+++ b/src/utils/AppDevRouter.js
@@ -3,17 +3,25 @@
 // serving up JSON responses based on HTTP verb
 
 import {
-    Router,
+    NextFunction,
     Request,
     Response,
-    NextFunction,
+    Router,
 } from 'express';
-import type { RequestType } from './Constants';
-import AppDevResponse from './AppDevResponse';
 
+import AppDevResponse from './AppDevResponse';
+import AppDevUtils from './AppDevUtils';
 import constants from './Constants';
 import lib from './Lib';
 import LogUtils from './LogUtils';
+
+import type { RequestType } from './Constants';
+
+/**
+ * ExpressHandlerFunction - the function signature of callbacks for Express
+ * Router objects
+ */
+export type ExpressCallback = (Request, Response, NextFunction) => any;
 
 /**
  * T is the response type for AppDevRouter
@@ -23,20 +31,13 @@ export default class AppDevRouter<T: Object> {
 
   requestType: RequestType;
 
-  authenticated: boolean;
-
   getPath(): string {
       throw LogUtils.logErr({ message: 'You must implement getPath() with a valid path' });
   }
 
-  constructor(type: RequestType, auth: ?boolean) {
+  constructor(type: RequestType) {
       this.router = new Router();
       this.requestType = type;
-      if (auth !== undefined && auth !== null) {
-          this.authenticated = auth;
-      } else {
-          this.authenticated = true;
-      }
 
       // Initialize this router
       this.init();
@@ -44,51 +45,35 @@ export default class AppDevRouter<T: Object> {
 
   init() {
       const path = this.getPath();
+      const middleware = this.middleware();
 
-      // Error handle path
-      if (path.length < 2) {
-          throw LogUtils.logErr({}, { path }, 'Invalid path');
-      } else if (path[0] !== '/') {
-          throw LogUtils.logErr({}, { path }, 'Path must start with a \'/\'');
-      } else if (path[path.length - 1] !== '/') {
-          throw LogUtils.logErr({}, { path }, 'Path must end with a \'/\'');
-      }
+      // Make sure path conforms to specifications
+      AppDevUtils.tryCheckAppDevURL(path);
+
       // Attach content to router
-      if (this.authenticated) {
-          switch (this.requestType) {
-              case constants.REQUEST_TYPES.GET:
-                  this.router.get(path, lib.ensureAuthenticated, this.response);
-                  break;
-              case constants.REQUEST_TYPES.POST:
-                  this.router.post(path, lib.ensureAuthenticated, this.response);
-                  break;
-              case constants.REQUEST_TYPES.DELETE:
-                  this.router.delete(path, lib.ensureAuthenticated, this.response);
-                  break;
-              case constants.REQUEST_TYPES.PUT:
-                  this.router.put(path, lib.ensureAuthenticated, this.response);
-                  break;
-              default:
-                  break;
-          }
-      } else {
-          switch (this.requestType) {
-              case constants.REQUEST_TYPES.GET:
-                  this.router.get(path, this.response);
-                  break;
-              case constants.REQUEST_TYPES.POST:
-                  this.router.post(path, this.response);
-                  break;
-              case constants.REQUEST_TYPES.DELETE:
-                  this.router.delete(path, this.response);
-                  break;
-              case constants.REQUEST_TYPES.PUT:
-                  this.router.put(path, this.response);
-                  break;
-              default:
-                  break;
-          }
+      switch (this.requestType) {
+          case constants.REQUEST_TYPES.GET:
+              this.router.get(path, middleware, this.response);
+              break;
+          case constants.REQUEST_TYPES.POST:
+              this.router.post(path, middleware, this.response);
+              break;
+          case constants.REQUEST_TYPES.DELETE:
+              this.router.delete(path, middleware, this.response);
+              break;
+          case constants.REQUEST_TYPES.PUT:
+              this.router.put(path, middleware, this.response);
+              break;
+          default:
+              break;
       }
+  }
+  
+  /**
+   * Subclasses must override this to supply middleware for the API.
+   */
+  middleware(): ExpressCallback {
+      return lib.ensureAuthenticated;
   }
 
   response = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/utils/AppDevRouter.js
+++ b/src/utils/AppDevRouter.js
@@ -72,8 +72,9 @@ export default class AppDevRouter<T: Object> {
   /**
    * Subclasses must override this to supply middleware for the API.
    */
-  middleware(): ExpressCallback {
-      return lib.ensureAuthenticated;
+  middleware(): ExpressCallback[] {
+      // By default makes route secured
+      return [lib.ensureAuthenticated];
   }
 
   response = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/utils/AppDevUtils.js
+++ b/src/utils/AppDevUtils.js
@@ -1,12 +1,21 @@
 // @flow
 // General utility functions / Objects helpful in a JS setting across
 // all AppDev projects
-import axios from 'axios';
 
-const googleAxios = axios.create({
-    baseURL: 'https://www.googleapis.com',
-    timeout: 5000,
-});
+/**
+ * Check if a string is an AppDev-formatted URL. An AppDev formatted URL is
+ * either just a '/', or begins and ends with a `/`, and must have some
+ * characters in between.
+ */
+const tryCheckAppDevURL = (path: string) => {
+    if (path !== '/' && path.length < 2) {
+        throw new Error('Invalid path!');
+    } else if (path[0] !== '/') {
+        throw new Error('Path must start with a \'/\'!');
+    } else if (path[path.length - 1] !== '/') {
+        throw new Error('Path must end with a \'/\'!');
+    }
+};
 
 /**
  * Extracts netid from email
@@ -26,7 +35,7 @@ const randomCode = (length: number): string => Math.round(((36 ** (length + 1)) 
     * (36 ** length))).toString(36).slice(1).toUpperCase();
 
 export default {
-    googleAxios,
     netIDFromEmail,
+    tryCheckAppDevURL,
     randomCode,
 };

--- a/src/utils/AppDevUtils.js
+++ b/src/utils/AppDevUtils.js
@@ -36,6 +36,6 @@ const randomCode = (length: number): string => Math.round(((36 ** (length + 1)) 
 
 export default {
     netIDFromEmail,
-    tryCheckAppDevURL,
     randomCode,
+    tryCheckAppDevURL,
 };


### PR DESCRIPTION
- Moved auth routers to their own files
- Allows custom middleware for individual routers
- By default, routers use middleware to secure route
- V1 routers override middleware to not be secure (@aliciaxw @yuna878 We should discuss whether we need to keep v1 routes or not)
- Remove `passport` and unneeded routes
