### PR TITLE
Fix travis deploy script to support multiple branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ deploy:
   script: bash docker_push
   skip_cleanup: true
   on:
-    branch: release
-    branch: master
+    all_branches: true
+    condition: $TRAVIS_BRANCH =~ ^master|release$
 script:
 - npm run start &
 - sleep 10; npm run test


### PR DESCRIPTION
As the title says, the original syntax only recognized the first branch stated. Syntax referenced from Travis documentation

![image](https://user-images.githubusercontent.com/22579863/53540752-c85cf300-3ae4-11e9-9c2e-51a861605178.png)
