### PR TITLE
Change poll/question ordering

### DIFF
--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -20,7 +20,7 @@ class Base {
   /** Set the timestamps to current time
   * @function
   */
-  setTimestamps() : void {
+  setTimestamps(): void {
     const time = Math.floor(new Date().getTime() / 1000);
     this.createdAt = time;
     this.updatedAt = time;
@@ -30,7 +30,7 @@ class Base {
   /** Set updatedAt timestamp to current time
   * @function
   */
-  updateTimestamps() : void {
+  updateTimestamps(): void {
     this.updatedAt = Math.floor(new Date().getTime() / 1000);
   }
 }

--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -312,12 +312,13 @@ const getUsersByGroupID = async (id: number, role: ?string):
 
 /**
  * Gets polls from a group sorted by creation date in ascending order.
- * Will hide poll results if poll is not shared.
+ * By default will hide poll results if poll is not shared.
  * @function
  * @param {number} id - ID of group to fetch polls from
+ * @param {boolean} hideUnsharedResults - Whether to return unaltered poll results for admins
  * @return {Poll[]} List of polls from group
  */
-const getPolls = async (id: number):
+const getPolls = async (id: number, hideUnsharedResults: ?boolean = true):
   Promise<Array<?Poll>> => {
   try {
     const group = await db().createQueryBuilder('groups')
@@ -327,14 +328,14 @@ const getPolls = async (id: number):
       .orderBy('polls.createdAt', 'ASC')
       .getOne();
     // obscure poll results if poll not shared
-    return group.polls.map(poll => (!poll.shared ? { ...poll, results: {} } : poll));
+    return group.polls.map(poll => (hideUnsharedResults && !poll.shared ? { ...poll, results: {} } : poll));
   } catch (e) {
     throw LogUtils.logErr(`Problem getting polls from group: ${id}`, e);
   }
 };
 
 /**
- * Get questions from a group sorted by creation date desc.
+ * Get questions from a group sorted by creation date in ascending order.
  * @function
  * @param {number} id - ID of group to fetch questions from
  * @return {Question[]} List of questions rom group
@@ -345,7 +346,7 @@ const getQuestions = async (id: number): Promise<Array<?Question>> => {
       .leftJoinAndSelect('groups.questions', 'questions')
       .where('groups.id = :groupID')
       .setParameters({ groupID: id })
-      .orderBy('questions.createdAt', 'DESC')
+      .orderBy('questions.createdAt', 'ASC')
       .getOne();
     return group.questions;
   } catch (e) {
@@ -364,12 +365,12 @@ const latestActivityByGroupID = async (id: number): Promise<?number> => {
     const group = await db().findOneById(id);
     if (!group) throw LogUtils.logErr(`Can't find group by id: ${id}`);
 
-    return await getPolls(id).then((p: Array<?Poll>) => {
-      const lastPoll = p.slice(-1).pop();
-      if (p.length === 0 || !lastPoll) {
+    return await getPolls(id).then((polls: Array<?Poll>) => {
+      const latestPoll = polls.slice(-1).pop();
+      if (polls.length === 0 || !latestPoll) {
         return group.updatedAt;
       }
-      return group.updatedAt > lastPoll.updatedAt ? group.updatedAt : lastPoll.updatedAt;
+      return group.updatedAt > latestPoll.updatedAt ? group.updatedAt : latestPoll.updatedAt;
     });
   } catch (e) {
     throw LogUtils.logErr(`Problem getting latest activity from group by id: ${id}`, e);

--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -324,7 +324,7 @@ const getPolls = async (id: number, sharedOnly: boolean):
       .leftJoinAndSelect('groups.polls', 'polls')
       .where('groups.id = :groupID')
       .setParameters({ groupID: id })
-      .orderBy('polls.createdAt', 'DESC')
+      .orderBy('polls.createdAt', 'ASC')
       .getOne();
     return sharedOnly === true ? group.polls.filter(poll => poll.shared) : group.polls;
   } catch (e) {

--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -17,7 +17,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
   async content(req: Request) {
     const { id } = req.params;
     const isAdmin = await GroupsRepo.isAdmin(id, req.user);
-    const polls = await GroupsRepo.getPolls(id, !isAdmin);
+    const polls = await GroupsRepo.getPolls(id);
     if (!polls) throw LogUtils.logErr(`Problem getting polls from group id: ${id}`);
 
     // List of all dates

--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -17,7 +17,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
   async content(req: Request) {
     const { id } = req.params;
     const isAdmin = await GroupsRepo.isAdmin(id, req.user);
-    const polls = await GroupsRepo.getPolls(id);
+    const polls = await GroupsRepo.getPolls(id, !isAdmin);
     if (!polls) throw LogUtils.logErr(`Problem getting polls from group id: ${id}`);
 
     // List of all dates

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -182,15 +182,16 @@ test('Get Polls from Group', async () => {
   let polls = await GroupsRepo.getPolls(id);
   expect(polls.length).toEqual(0);
 
-  const poll = await PollsRepo.createPoll('Poll', group, {}, true, 'MULTIPLE_CHOICE', '');
-  const poll2 = await PollsRepo.createPoll('', group, {}, false, 'FREE_RESPONSE', '', {});
-  polls = await GroupsRepo.getPolls(id, true);
-  expect(polls.length).toEqual(1);
-  expect(polls[0].id).toBe(poll.id);
-  polls = await GroupsRepo.getPolls(id, false);
+  const results = { A: { text: 'blue', count: 1 } };
+  const results2 = { 1: { text: 'blue', count: 0 }, 2: { text: 'red', count: 2 } };
+  const poll = await PollsRepo.createPoll('Poll', group, results, true, 'MULTIPLE_CHOICE', '');
+  const poll2 = await PollsRepo.createPoll('', group, results2, false, 'FREE_RESPONSE', '', {});
+  polls = await GroupsRepo.getPolls(id);
   expect(polls.length).toEqual(2);
   expect(polls[0].id).toBe(poll.id);
   expect(polls[1].id).toBe(poll2.id);
+  expect(polls[0].results).toEqual(poll.results);
+  expect(polls[1].results).toEqual({});
 
   await PollsRepo.deletePollByID(poll.id);
   await PollsRepo.deletePollByID(poll2.id);

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -192,6 +192,9 @@ test('Get Polls from Group', async () => {
   expect(polls[1].id).toBe(poll2.id);
   expect(polls[0].results).toEqual(poll.results);
   expect(polls[1].results).toEqual({});
+  polls = await GroupsRepo.getPolls(id, false); // if admin, don't hide results
+  expect(polls[0].results).toEqual(poll.results);
+  expect(polls[1].results).toEqual(poll2.results);
 
   await PollsRepo.deletePollByID(poll.id);
   await PollsRepo.deletePollByID(poll2.id);

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -76,10 +76,8 @@ test('Get Group from Poll', async () => {
 test('Get Polls from Group', async () => {
   await PollsRepo
     .createPoll('Another poll', group, {}, true, 'FREE_RESPONSE', '');
-  let polls = await GroupsRepo.getPolls(group.id, false);
+  const polls = await GroupsRepo.getPolls(group.id);
   expect(polls.length).toBe(3);
-  polls = await GroupsRepo.getPolls(group.id, true);
-  expect(polls.length).toBe(1);
 });
 
 test('Delete Poll', async () => {


### PR DESCRIPTION
- Getting polls/questions by group will be in ascending order (oldest to newest), should fix last live times bug
- Getting polls will return all polls in a group (not just shared polls), but poll results that are unshared will be hidden (set to `{}`)
- Minor variable renames and documentation updates for clarity