### PR TITLE
Fix flow errors with Groups API

### DIFF
--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -360,7 +360,7 @@ const getQuestions = async (id: number): Promise<Array<?Question>> => {
  * @param {number} id - ID of group to get latest activity
  * @return {number} Time stamp of when the group was last updated
  */
-const latestActivityByGroupID = async (id: number): Promise<?number> => {
+const latestActivityByGroupID = async (id: number): Promise<number> => {
   try {
     const group = await db().findOneById(id);
     if (!group) throw LogUtils.logErr(`Can't find group by id: ${id}`);
@@ -368,9 +368,11 @@ const latestActivityByGroupID = async (id: number): Promise<?number> => {
     return await getPolls(id).then((polls: Array<?Poll>) => {
       const latestPoll = polls.slice(-1).pop();
       if (polls.length === 0 || !latestPoll) {
-        return group.updatedAt;
+        return Number(group.updatedAt);
       }
-      return group.updatedAt > latestPoll.updatedAt ? group.updatedAt : latestPoll.updatedAt;
+      return group.updatedAt > latestPoll.updatedAt
+        ? Number(group.updatedAt)
+        : Number(latestPoll.updatedAt);
     });
   } catch (e) {
     throw LogUtils.logErr(`Problem getting latest activity from group by id: ${id}`, e);

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -16,7 +16,7 @@ export type APIGroup = {|
   code: string,
   isLive: boolean,
   name: string,
-  updatedAt: string,
+  updatedAt: number,
 |}
 
 export type APIPoll = {|

--- a/src/routers/v2/Groups/GetGroupRouter.js
+++ b/src/routers/v2/Groups/GetGroupRouter.js
@@ -22,8 +22,10 @@ class GetGroupRouter extends AppDevRouter<APIGroup> {
 
     return {
       id: group.id,
-      name: group.name,
       code: group.code,
+      isLive: await req.app.groupManager.isLive(group.code),
+      name: group.name,
+      updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
     };
   }
 }

--- a/src/routers/v2/Groups/PostGroupRouter.js
+++ b/src/routers/v2/Groups/PostGroupRouter.js
@@ -29,8 +29,10 @@ class PostGroupRouter extends AppDevRouter<APIGroup> {
 
     return {
       id: group.id,
-      name: group.name,
       code: group.code,
+      isLive: false,
+      name: group.name,
+      updatedAt: group.updatedAt,
     };
   }
 }

--- a/src/routers/v2/Groups/UpdateGroupRouter.js
+++ b/src/routers/v2/Groups/UpdateGroupRouter.js
@@ -40,8 +40,10 @@ class UpdateGroupRouter extends AppDevRouter<APIGroup> {
     }
     return {
       id: group.id,
-      name: group.name,
       code: group.code,
+      isLive: await req.app.groupManager.isLive(group.code),
+      name: group.name,
+      updatedAt: group.updatedAt,
     };
   }
 }

--- a/src/routers/v2/StartGroupRouter.js
+++ b/src/routers/v2/StartGroupRouter.js
@@ -31,8 +31,10 @@ class StartGroupRouter extends AppDevRouter<APIGroup> {
 
     return {
       id: group.id,
-      name: group.name,
       code: group.code,
+      isLive: true,
+      name: group.name,
+      updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
     };
   }
 }


### PR DESCRIPTION
- Some of the Group routes are missing `updatedAt` and `isLive` in their return values 
- The client doesn't use all of these values for some of the routes but the APIGroup type specifies them 
- For uniformity, I've added them, but we could make these fields optional. **Thoughts**?