### PR TITLE
Standardize timestamps to string

### DIFF
--- a/src/GroupManager.js
+++ b/src/GroupManager.js
@@ -48,8 +48,6 @@ class GroupManager {
     if (socket.closing) return;
     socket.closing = true;
 
-    if (save) socket.saveGroup();
-
     const connectedSockets = Object.keys(socket.nsp.connected);
     connectedSockets.forEach((id) => {
       socket.nsp.connected[id].disconnect();

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -10,18 +10,18 @@ import {
 class Base {
   @Column('bigint')
   /** Created at timestamp (Unix time) */
-  createdAt: number = -1;
+  createdAt: string = '-1';
 
   @Column('bigint')
   /** Updated at timestamp (Unix time) */
-  updatedAt: number = -1;
+  updatedAt: string = '-1';
 
   @BeforeInsert()
   /** Set the timestamps to current time
   * @function
   */
   setTimestamps(): void {
-    const time = Math.floor(new Date().getTime() / 1000);
+    const time = String(Math.floor(new Date().getTime() / 1000));
     this.createdAt = time;
     this.updatedAt = time;
   }
@@ -31,7 +31,7 @@ class Base {
   * @function
   */
   updateTimestamps(): void {
-    this.updatedAt = Math.floor(new Date().getTime() / 1000);
+    this.updatedAt = String(Math.floor(new Date().getTime() / 1000));
   }
 }
 

--- a/src/models/UserSession.js
+++ b/src/models/UserSession.js
@@ -26,7 +26,7 @@ class UserSession extends Base {
 
   @Column('bigint')
   /** Timestamp of when the session expires (Unix time) */
-  expiresAt: number = -1;
+  expiresAt: string = '-1';
 
   @Column('string')
   /** Refresh token associated with session */
@@ -69,7 +69,7 @@ class UserSession extends Base {
     this.updateToken = updateToken || crypto.randomBytes(64).toString('hex');
 
     // Session length is 1 day
-    this.expiresAt = Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24;
+    this.expiresAt = String(Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24);
     this.activate();
     return this;
   }

--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -358,9 +358,9 @@ const getQuestions = async (id: number): Promise<Array<?Question>> => {
  * Get time of latest activity of a group
  * @function
  * @param {number} id - ID of group to get latest activity
- * @return {number} Time stamp of when the group was last updated
+ * @return {string} Time stamp of when the group was last updated
  */
-const latestActivityByGroupID = async (id: number): Promise<number> => {
+const latestActivityByGroupID = async (id: number): Promise<string> => {
   try {
     const group = await db().findOneById(id);
     if (!group) throw LogUtils.logErr(`Can't find group by id: ${id}`);
@@ -368,11 +368,11 @@ const latestActivityByGroupID = async (id: number): Promise<number> => {
     return await getPolls(id).then((polls: Array<?Poll>) => {
       const latestPoll = polls.slice(-1).pop();
       if (polls.length === 0 || !latestPoll) {
-        return Number(group.updatedAt);
+        return group.updatedAt;
       }
-      return group.updatedAt > latestPoll.updatedAt
-        ? Number(group.updatedAt)
-        : Number(latestPoll.updatedAt);
+      return parseInt(group.updatedAt) > parseInt(latestPoll.updatedAt)
+        ? group.updatedAt
+        : latestPoll.updatedAt;
     });
   } catch (e) {
     throw LogUtils.logErr(`Problem getting latest activity from group by id: ${id}`, e);

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -16,7 +16,7 @@ export type APIGroup = {|
   code: string,
   isLive: boolean,
   name: string,
-  updatedAt: number,
+  updatedAt: string,
 |}
 
 export type APIPoll = {|
@@ -31,14 +31,14 @@ export type APIPoll = {|
 
 export type APIDraft = {|
   id: id,
-  createdAt?: number,
+  createdAt: string,
   options: string[],
   text: string,
 |}
 
 export type APIQuestion = {|
   id: id,
-  createdAt?: number,
+  createdAt: string,
   text: string,
 |}
 
@@ -52,5 +52,5 @@ export type APIUserSession = {|
   accessToken: string,
   isActive: boolean,
   refreshToken: string,
-  sessionExpiration: number,
+  sessionExpiration: string,
 |}

--- a/src/routers/v2/Drafts/GetDraftsRouter.js
+++ b/src/routers/v2/Drafts/GetDraftsRouter.js
@@ -22,9 +22,9 @@ class GetDraftsRouter extends AppDevRouter<APIDraft[]> {
       .filter(Boolean)
       .map(draft => ({
         id: draft.id,
+        createdAt: draft.createdAt,
         text: draft.text,
         options: draft.options,
-        createdAt: draft.createdAt.valueOf(),
       }));
   }
 }

--- a/src/routers/v2/Drafts/PostDraftRouter.js
+++ b/src/routers/v2/Drafts/PostDraftRouter.js
@@ -26,6 +26,7 @@ class PostDraftRouter extends AppDevRouter<APIDraft> {
 
     return {
       id: draft.id,
+      createdAt: draft.createdAt,
       text: draft.text,
       options: draft.options,
     };

--- a/src/routers/v2/Drafts/UpdateDraftRouter.js
+++ b/src/routers/v2/Drafts/UpdateDraftRouter.js
@@ -38,6 +38,7 @@ class UpdateDraftRouter extends AppDevRouter<APIDraft> {
 
     return {
       id: draft.id,
+      createdAt: draft.createdAt,
       text: draft.text,
       options: draft.options,
     };

--- a/src/routers/v2/Questions/GetQuestionRouter.js
+++ b/src/routers/v2/Questions/GetQuestionRouter.js
@@ -23,6 +23,7 @@ class GetQuestionRouter extends AppDevRouter<APIQuestion> {
 
     return question && {
       id: question.id,
+      createdAt: question.createdAt,
       text: question.text,
     };
   }

--- a/src/routers/v2/Questions/GetQuestionsRouter.js
+++ b/src/routers/v2/Questions/GetQuestionsRouter.js
@@ -23,8 +23,8 @@ class GetQuestionsRouter extends AppDevRouter<APIQuestion[]> {
       .filter(Boolean)
       .map(question => ({
         id: question.id,
+        createdAt: question.createdAt,
         text: question.text,
-        createdAt: question.createdAt.valueOf(),
       }));
   }
 }

--- a/src/routers/v2/Questions/PostQuestionRouter.js
+++ b/src/routers/v2/Questions/PostQuestionRouter.js
@@ -31,11 +31,12 @@ class PostQuestionRouter extends AppDevRouter<APIQuestion> {
       throw LogUtils.logErr('You are not authorized to post a poll', {}, { groupID, user });
     }
 
-    const poll = await QuestionsRepo.createQuestion(text, group, user);
+    const question = await QuestionsRepo.createQuestion(text, group, user);
 
     return {
-      id: poll.id,
-      text: poll.text,
+      id: question.id,
+      createdAt: question.createdAt,
+      text: question.text,
     };
   }
 }

--- a/src/routers/v2/Questions/UpdateQuestionRouter.js
+++ b/src/routers/v2/Questions/UpdateQuestionRouter.js
@@ -36,6 +36,7 @@ class UpdateQuestionRouter extends AppDevRouter<APIQuestion> {
 
     return {
       id: question.id,
+      createdAt: question.createdAt,
       text: question.text,
     };
   }

--- a/test/routes/api.draft.test.js
+++ b/test/routes/api.draft.test.js
@@ -62,6 +62,7 @@ test('Update a draft', async () => {
     expect(draft.text).toBe(body.text);
     expect(draft.options).toMatchObject(draft1.options);
     expect(draft.id).toBe(draft1.id);
+    expect(draft.createdAt).toBe(draft1.createdAt);
     draft1 = draft;
   });
 });

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -55,6 +55,7 @@ test('get groups for admin', async () => {
     expect(group.id).toBe(groupRes.id);
     expect(group.name).toBe(groupRes.name);
     expect(group.code).toBe(groupRes.code);
+    expect(group.updatedAt).toBe(groupRes.updatedAt);
   });
 });
 
@@ -111,6 +112,7 @@ test('get groups as member', async () => {
     expect(group.id).toBe(groupRes.id);
     expect(group.name).toBe(groupRes.name);
     expect(group.code).toBe(groupRes.code);
+    expect(group.updatedAt).toBe(groupRes.updatedAt);
   });
 });
 
@@ -162,6 +164,7 @@ test('get groups for admin', async () => {
     expect(group.id).toBe(groupRes.id);
     expect(group.name).toBe(groupRes.name);
     expect(group.code).toBe(groupRes.code);
+    expect(group.updatedAt).toBe(groupRes.updatedAt);
   });
 });
 

--- a/test/routes/api.question.test.js
+++ b/test/routes/api.question.test.js
@@ -60,6 +60,8 @@ test('get question by id', async () => {
   await request(get(`/questions/${question.id}`, memberToken)).then((getres) => {
     expect(getres.success).toBe(true);
     expect(question.id).toBe(getres.data.id);
+    expect(question.createdAt).toBe(getres.data.createdAt);
+    expect(question.text).toBe(getres.data.text);
   });
 });
 
@@ -67,6 +69,8 @@ test('get questions by group', async () => {
   await request(get(`/sessions/${group.id}/questions`, adminToken)).then((getres) => {
     expect(getres.success).toBe(true);
     expect(question.id).toBe(getres.data[0].id);
+    expect(question.createdAt).toBe(getres.data[0].createdAt);
+    expect(question.text).toBe(getres.data[0].text);
   });
 });
 


### PR DESCRIPTION
- We use the `bigint` type for timestamps in our postgres db
- However, every time we query from the database, all values in columns with type `bigint` are actually returned as a string instead of a number since javascript's number type doesn't support as large of numbers as `bigint`
- Turns out that iOS has been expecting strings for all of these timestamps
- Instead of using a `number` type for timestamps, it makes sense to just change it to string since that's consistent with postgres and iOS