### PR TITLE
Group location support

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -107,7 +107,7 @@ export default class GroupSocket {
       return;
     }
 
-    const userType = await GroupsRepo.isAdmin(this.group.id, user) ? 'admin' : 'member';
+    const userType = (await GroupsRepo.isAdmin(this.group.id, user)) ? 'admin' : 'member';
 
     switch (userType) {
       case 'admin': {
@@ -181,149 +181,149 @@ export default class GroupSocket {
           if (badWords.length > 0) { // not clean text
             client.emit('user/poll/fr/filter',
               ({ success: false, text: submittedAnswer.text, filter: badWords }: PollFilter));
-            return;
-          }
-          if (poll.answers[googleID]) { // User submitted another FR answer
-            poll.answers[googleID].push(submittedAnswer);
-            poll.upvotes[googleID].push(submittedAnswer);
-          } else { // User submitted first FR answer
-            poll.answers[googleID] = [submittedAnswer];
-            poll.upvotes[googleID] = [submittedAnswer];
-          }
+    return;
+  }
+  if(poll.answers[googleID]) { // User submitted another FR answer
+    poll.answers[googleID].push(submittedAnswer);
+    poll.upvotes[googleID].push(submittedAnswer);
+  } else { // User submitted first FR answer
+  poll.answers[googleID] = [submittedAnswer];
+  poll.upvotes[googleID] = [submittedAnswer];
+}
 
-          poll.answerChoices.push({ count: 1, text: submittedAnswer.text, letter: null });
-          client.emit('user/poll/fr/filter', ({ success: true }: PollFilter));
-          break;
+poll.answerChoices.push({ count: 1, text: submittedAnswer.text, letter: null });
+client.emit('user/poll/fr/filter', ({ success: true }: PollFilter));
+break;
         }
         default:
-          throw new Error('Unimplemented question type');
+throw new Error('Unimplemented question type');
       }
 
-      this.current = poll;
+this.current = poll;
 
-      this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
+this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
 
-      if (poll.type === constants.QUESTION_TYPES.FREE_RESPONSE) {
-        this.nsp.to('users').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-      }
+if (poll.type === constants.QUESTION_TYPES.FREE_RESPONSE) {
+  this.nsp.to('users').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
+}
     });
 
-    client.on('server/poll/upvote', (upvoteObject: PollChoice) => {
-      const { text } = upvoteObject;
-      const poll = this.current;
-      if (!poll || !text) {
-        // console.log(`Client with googleID ${googleID} tried to answer with no active poll`);
-        return;
-      }
-
-      const currAnswer: ?PollResult = poll.answerChoices.find((p: PollResult) => p.text === text);
-      if (currAnswer) { // User selected a valid answer
-        const userUpvotes = poll.upvotes[googleID];
-        if (userUpvotes) { // User upvoted something before
-          if (userUpvotes.find((p: PollChoice) => p.text === text)) { // unupvote
-            poll.upvotes[googleID] = userUpvotes.filter(p => p.text !== text);
-            poll.answerChoices.forEach((p: PollResult) => {
-              if (p.count && p.text === text) { p.count -= 1; }
-            });
-          } else { // upvote
-            poll.upvotes[googleID].push({ text });
-            poll.answerChoices.forEach((p: PollResult) => {
-              if (p.count && p.text === text) { p.count += 1; }
-            });
-          }
-        } else { // init array and upvote
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.count && p.text === text) { p.count -= 1; }
-          });
-          poll.upvotes[googleID] = [{ text }];
-        }
-      }
-
-      this.current = poll;
-
-      this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
-      if (poll.type === constants.QUESTION_TYPES.FREE_RESPONSE) {
-        this.nsp.to('users').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-      }
-    });
-
-    client.on('disconnect', async () => {
-      // console.log(`User ${client.id} disconnected.`);
-      if (this.nsp.connected.length === 0) {
-        await this._endPoll();
-        this.onClose();
-      }
-    });
+client.on('server/poll/upvote', (upvoteObject: PollChoice) => {
+  const { text } = upvoteObject;
+  const poll = this.current;
+  if (!poll || !text) {
+    // console.log(`Client with googleID ${googleID} tried to answer with no active poll`);
+    return;
   }
 
-  // *************************** Admin Side ***************************
+  const currAnswer: ?PollResult = poll.answerChoices.find((p: PollResult) => p.text === text);
+  if (currAnswer) { // User selected a valid answer
+    const userUpvotes = poll.upvotes[googleID];
+    if (userUpvotes) { // User upvoted something before
+      if (userUpvotes.find((p: PollChoice) => p.text === text)) { // unupvote
+        poll.upvotes[googleID] = userUpvotes.filter(p => p.text !== text);
+        poll.answerChoices.forEach((p: PollResult) => {
+          if (p.count && p.text === text) { p.count -= 1; }
+        });
+      } else { // upvote
+        poll.upvotes[googleID].push({ text });
+        poll.answerChoices.forEach((p: PollResult) => {
+          if (p.count && p.text === text) { p.count += 1; }
+        });
+      }
+    } else { // init array and upvote
+      poll.answerChoices.forEach((p: PollResult) => {
+        if (p.count && p.text === text) { p.count -= 1; }
+      });
+      poll.upvotes[googleID] = [{ text }];
+    }
+  }
 
-  /**
+  this.current = poll;
+
+  this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
+  if (poll.type === constants.QUESTION_TYPES.FREE_RESPONSE) {
+    this.nsp.to('users').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
+  }
+});
+
+client.on('disconnect', async () => {
+  // console.log(`User ${client.id} disconnected.`);
+  if (this.nsp.connected.length === 0) {
+    await this._endPoll();
+    this.onClose();
+  }
+});
+  }
+
+// *************************** Admin Side ***************************
+
+/**
 * Gives current poll
 * @param {String} userRole
 * @return {?ClientPoll} Socket poll object
 */
-  _currentPoll(userRole: string): ClientPoll | null {
-    if (!this.current) return null; // no live poll
-    let { correctAnswer } = this.current;
-    const {
-      createdAt, updatedAt, answers, answerChoices, state, text, type, upvotes,
-    } = this.current;
-    const pollID = this.current.id;
+_currentPoll(userRole: string): ClientPoll | null {
+  if (!this.current) return null; // no live poll
+  let { correctAnswer } = this.current;
+  const {
+    createdAt, updatedAt, answers, answerChoices, state, text, type, upvotes,
+  } = this.current;
+  const pollID = this.current.id;
 
-    let userAnswers;
-    const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
-    if (isMultipleChoice) {
-      userAnswers = answers;
-    } else {
-      userAnswers = upvotes;
-    }
-    if (!userAnswers) userAnswers = {};
-    if (!correctAnswer) correctAnswer = '';
-
-    const filteredChoices = userRole === 'admin'
-      || !isMultipleChoice
-      || state === constants.POLL_STATES.SHARED
-      ? answerChoices
-      : answerChoices.map((a) => {
-        a.count = null;
-        return a;
-      });
-
-    return {
-      pollID,
-      createdAt,
-      updatedAt,
-      answerChoices: filteredChoices,
-      correctAnswer,
-      state,
-      text,
-      type,
-      userAnswers,
-    };
+  let userAnswers;
+  const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
+  if (isMultipleChoice) {
+    userAnswers = answers;
+  } else {
+    userAnswers = upvotes;
   }
+  if (!userAnswers) userAnswers = {};
+  if (!correctAnswer) correctAnswer = '';
 
-  /**
+  const filteredChoices = userRole === 'admin'
+    || !isMultipleChoice
+    || state === constants.POLL_STATES.SHARED
+    ? answerChoices
+    : answerChoices.map((a) => {
+      a.count = null;
+      return a;
+    });
+
+  return {
+    pollID,
+    createdAt,
+    updatedAt,
+    answerChoices: filteredChoices,
+    correctAnswer,
+    state,
+    text,
+    type,
+    userAnswers,
+  };
+}
+
+/**
 * Starts poll on the socket
 * @param {ClientPoll} poll - Poll object to start
 */
-  _startPoll(poll: ClientPoll) {
+_startPoll(poll: ClientPoll) {
   // start new poll
-    const newPoll: SocketPoll = {
-      answerChoices: poll.answerChoices,
-      correctAnswer: poll.correctAnswer,
-      state: constants.POLL_STATES.LIVE,
-      text: poll.text,
-      type: poll.type,
-      answers: {},
-      upvotes: {},
-    };
+  const newPoll: SocketPoll = {
+    answerChoices: poll.answerChoices,
+    correctAnswer: poll.correctAnswer,
+    state: constants.POLL_STATES.LIVE,
+    text: poll.text,
+    type: poll.type,
+    answers: {},
+    upvotes: {},
+  };
 
-    this.current = newPoll;
-    this.isLive = true;
+  this.current = newPoll;
+  this.isLive = true;
 
-    this.nsp.to('users').emit('user/poll/start', this._currentPoll(constants.USER_TYPES.MEMBER));
-  }
+  this.nsp.to('users').emit('user/poll/start', this._currentPoll(constants.USER_TYPES.MEMBER));
+}
 
 /**
  * Ends current poll
@@ -400,7 +400,7 @@ _deleteLivePoll = () => {
 _setupAdminEvents(client: IOSocket): void {
   const { address } = client.handshake;
 
-  if (!address) {
+  if(!address) {
     this._clientError(client, 'No client address');
     return;
   }

--- a/src/models/Group.js
+++ b/src/models/Group.js
@@ -12,6 +12,8 @@ import Poll from './Poll';
 import Question from './Question';
 import User from './User';
 
+export type Coord = {| lat: ?number, long: ?number |}
+
 @Entity('groups')
 /**
  * Group class represents a grouping of polls.
@@ -29,6 +31,14 @@ class Group extends Base {
   @Column('string')
   /** Unique code to join group */
   code: string = '';
+
+  @Column('json')
+  /** Most recent coordinates of the admin of the group */
+  location: Coord = { lat: null, long: null };
+
+  @Column('boolean')
+  /** If joining a group requires user to be within 300m of the group location */
+  isLocationRestricted: boolean = false
 
   @ManyToMany(type => User, user => user.adminGroups)
   @JoinTable()

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -1,4 +1,5 @@
 // @flow
+import type { Coord } from '../../models/Group';
 import type { PollChoice, PollState, PollType } from '../../utils/Constants';
 import type { PollResult } from '../../models/Poll';
 
@@ -17,6 +18,8 @@ export type APIGroup = {|
   id: id,
   code: string,
   isLive: boolean,
+  isLocationRestricted: boolean,
+  location: Coord,
   name: string,
   updatedAt: string,
 |}

--- a/src/routers/v2/Groups/DeleteGroupRouter.js
+++ b/src/routers/v2/Groups/DeleteGroupRouter.js
@@ -25,7 +25,7 @@ class DeleteGroupRouter extends AppDevRouter<NoResponse> {
 
     if (!await GroupsRepo.isAdmin(groupID, user)) {
       throw LogUtils.logErr(
-        'You are not authorized to delete this group', {}, { groupID, user },
+        `You are not authorized to delete group: ${groupID}`, {}, { user },
       );
     }
 

--- a/src/routers/v2/Groups/GetAdminGroupsRouter.js
+++ b/src/routers/v2/Groups/GetAdminGroupsRouter.js
@@ -28,6 +28,8 @@ class GetGroupsRouter extends AppDevRouter<APIGroup[]> {
         code: group.code,
         updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
         isLive: await req.app.groupManager.isLive(group.code),
+        isLocationRestricted: group.isLocationRestricted,
+        location: group.location,
       }));
     return Promise.all(nodes).then(n => n);
   }

--- a/src/routers/v2/Groups/GetGroupRouter.js
+++ b/src/routers/v2/Groups/GetGroupRouter.js
@@ -24,6 +24,8 @@ class GetGroupRouter extends AppDevRouter<APIGroup> {
       id: group.id,
       code: group.code,
       isLive: await req.app.groupManager.isLive(group.code),
+      isLocationRestricted: group.isLocationRestricted,
+      location: group.location,
       name: group.name,
       updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
     };

--- a/src/routers/v2/Groups/GetGroupsRouter.js
+++ b/src/routers/v2/Groups/GetGroupsRouter.js
@@ -28,6 +28,8 @@ class GetGroupsRouter extends AppDevRouter<APIGroup[]> {
         code: group.code,
         updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
         isLive: await req.app.groupManager.isLive(group.code),
+        isLocationRestricted: group.isLocationRestricted,
+        location: group.location,
       }));
     return Promise.all(nodes).then(n => n);
   }

--- a/src/routers/v2/Groups/PostGroupRouter.js
+++ b/src/routers/v2/Groups/PostGroupRouter.js
@@ -17,20 +17,23 @@ class PostGroupRouter extends AppDevRouter<APIGroup> {
   }
 
   async content(req: Request) {
-    let { name } = req.body;
+    let { name, location } = req.body;
     const { code } = req.body;
     const { user } = req;
 
     if (!name) name = '';
     if (!user) throw LogUtils.logErr('User missing');
     if (!code) throw LogUtils.logErr('Group code missing');
+    if (!location) location = { lat: null, long: null };
 
-    const group = await GroupsRepo.createGroup(name, code, user);
+    const group = await GroupsRepo.createGroup(name, code, user, location);
 
     return {
       id: group.id,
       code: group.code,
       isLive: false,
+      isLocationRestricted: group.isLocationRestricted,
+      location: group.location,
       name: group.name,
       updatedAt: group.updatedAt,
     };

--- a/src/routers/v2/Groups/UpdateGroupRouter.js
+++ b/src/routers/v2/Groups/UpdateGroupRouter.js
@@ -17,11 +17,13 @@ class UpdateGroupRouter extends AppDevRouter<APIGroup> {
   }
 
   async content(req: Request) {
-    const { name } = req.body;
+    const { isRestricted, name } = req.body;
     const groupID = req.params.id;
     const { user } = req;
 
-    if (!name) throw LogUtils.logErr('No fields specified to update');
+    if (!name && (isRestricted === null || isRestricted === undefined)) {
+      throw LogUtils.logErr('No fields specified to update');
+    }
 
     let group = await GroupsRepo.getGroupByID(groupID);
     if (!group) {
@@ -34,14 +36,17 @@ class UpdateGroupRouter extends AppDevRouter<APIGroup> {
       );
     }
 
-    group = await GroupsRepo.updateGroupByID(groupID, name);
+    group = await GroupsRepo.updateGroupByID(groupID, name, null, isRestricted);
     if (!group) {
       throw LogUtils.logErr(`Group with id ${groupID} was not found`);
     }
+
     return {
       id: group.id,
       code: group.code,
       isLive: await req.app.groupManager.isLive(group.code),
+      isLocationRestricted: group.isLocationRestricted,
+      location: group.location,
       name: group.name,
       updatedAt: group.updatedAt,
     };

--- a/src/routers/v2/JoinGroupRouter.js
+++ b/src/routers/v2/JoinGroupRouter.js
@@ -4,6 +4,7 @@ import AppDevRouter from '../../utils/AppDevRouter';
 import constants from '../../utils/Constants';
 import GroupsRepo from '../../repos/GroupsRepo';
 import LogUtils from '../../utils/LogUtils';
+import lib from '../../utils/Lib';
 
 import type { APIGroup } from './APITypes';
 
@@ -17,7 +18,7 @@ class JoinGroupRouter extends AppDevRouter<APIGroup> {
   }
 
   async content(req: Request) {
-    const { code } = req.body;
+    const { code, location } = req.body;
     let { id } = req.body;
     const { user } = req;
 
@@ -34,19 +35,40 @@ class JoinGroupRouter extends AppDevRouter<APIGroup> {
       }
     }
 
-    const group = await GroupsRepo.getGroupByID(id);
+    let group = await GroupsRepo.getGroupByID(id);
     if (!group) {
       throw LogUtils.logErr(`No group with id ${id} found`);
-    }
-
-    if (req.app.groupManager.findSocket(code, id) === undefined) {
-      await req.app.groupManager.startNewGroup(group);
     }
 
     // add user as member if not in group in database
     const [isAdmin, isMember] = await Promise.all(
       [GroupsRepo.isAdmin(id, user), GroupsRepo.isMember(id, user)],
     );
+
+    // if admin, update group's location if the location is non-null
+    if (isAdmin) {
+      const updatedGroup = await GroupsRepo.updateGroupByID(id, null, location);
+      if (updatedGroup) group = updatedGroup;
+    }
+
+    // handle location restriction constraints for members
+    if (isMember && group.isLocationRestricted) {
+      if (!location || !location.lat || !location.long) {
+        throw LogUtils.logErr('User with no location tried to join a location restricted group');
+      }
+
+      if (!group.location.lat || !group.location.long) {
+        throw LogUtils.logErr('Location restricted group has a null location');
+      } else {
+        const withinRadius = lib.isWithin300m(location, group.location);
+        if (!withinRadius) throw LogUtils.logErr('Out of range user tried to join group');
+      }
+    }
+
+    if (req.app.groupManager.findSocket(code, id) === undefined) {
+      await req.app.groupManager.startNewGroup(group);
+    }
+
     if (!isAdmin && !isMember) {
       await GroupsRepo.addUsersByIDs(id, [user.id], 'member');
     }
@@ -55,6 +77,8 @@ class JoinGroupRouter extends AppDevRouter<APIGroup> {
       id: group.id,
       code: group.code,
       isLive: await req.app.groupManager.isLive(group.code),
+      isLocationRestricted: group.isLocationRestricted,
+      location: group.location,
       name: group.name,
       updatedAt: group.updatedAt,
     };

--- a/src/routers/v2/StartGroupRouter.js
+++ b/src/routers/v2/StartGroupRouter.js
@@ -17,7 +17,7 @@ class StartGroupRouter extends AppDevRouter<APIGroup> {
   }
 
   async content(req: Request) {
-    const { code } = req.body;
+    const { code, location } = req.body;
     let { name } = req.body;
 
     if (!name) name = '';
@@ -26,13 +26,15 @@ class StartGroupRouter extends AppDevRouter<APIGroup> {
       throw LogUtils.logErr('Code required');
     }
 
-    const group = await GroupsRepo.createGroup(name, code, req.user);
+    const group = await GroupsRepo.createGroup(name, code, req.user, location);
     await req.app.groupManager.startNewGroup(group);
 
     return {
       id: group.id,
       code: group.code,
       isLive: true,
+      isLocationRestricted: group.isLocationRestricted,
+      location: group.location,
       name: group.name,
       updatedAt: await GroupsRepo.latestActivityByGroupID(group.id),
     };

--- a/src/utils/Lib.js
+++ b/src/utils/Lib.js
@@ -7,6 +7,9 @@ import {
 import profanity from 'profanity-util';
 import AppDevResponse from './AppDevResponse';
 import UserSessionsRepo from '../repos/UserSessionsRepo';
+import LogUtils from './LogUtils';
+
+import type { Coord } from '../models/Group';
 
 /** Removes element from array on predicate
 * @function
@@ -118,9 +121,29 @@ async function updateSession(req: Request, res: Response, next: NextFunction) {
  */
 const filterProfanity = (str: string): Array<String> => profanity.check(str); // => [ 'badword1', 'badword2']
 
+/**
+ * Checks if the new location is within 300 meters of the
+ * old location using Haversine's formula
+ */
+const isWithin300m = (userCoords: Coord, groupCoords: Coord): boolean => {
+  const lat2 = userCoords.lat;
+  const lat1 = groupCoords.lat;
+  const long2 = userCoords.long;
+  const long1 = groupCoords.long;
+  if (lat2 && lat1 && long2 && long1) {
+    const p = Math.PI / 180;
+    const c = Math.cos;
+    const a = 0.5 - c((lat2 - lat1) * p) / 2 + c(lat1 * p) * c(lat2 * p) * (1 - c((long2 - long1) * p)) / 2;
+    const d = 1000 * 12742 * Math.asin(Math.sqrt(a)); // distance between userCoords and groupCoords in meters
+    return d <= 300;
+  }
+  throw LogUtils.logErr('Cannot perform arithmetic on undefined coordinates');
+};
+
 export default {
   remove,
   ensureAuthenticated,
   filterProfanity,
   updateSession,
+  isWithin300m,
 };

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -11,8 +11,9 @@ const {
 // Groups
 // Must be running server to test
 
-const opts = { name: 'Test group', code: GroupsRepo.createCode() };
+const opts = { name: 'Test group', code: GroupsRepo.createCode(), location: { lat: 1, long: -0.5 } };
 const opts2 = { name: 'New group' };
+const opts3 = { isRestricted: true };
 const googleID = 'usertest';
 let adminToken;
 let userToken;
@@ -123,6 +124,28 @@ test('get members of group', async () => {
     expect(members.length).toBe(1);
     expect(members[0].id).toBe(userID);
   });
+});
+
+test('get group location restriction', async () => {
+  const isRestricted = await GroupsRepo.isLocationRestricted(group.id);
+  expect(isRestricted).toBe(false);
+});
+
+test('update group location restriction', async () => {
+  await request(put(`/sessions/${group.id}/`, opts3, adminToken)).then((getres) => {
+    expect(getres.success).toBe(true);
+    expect(getres.data.isLocationRestricted).toBe(true);
+  });
+});
+
+test('update group location as admin with non-null location', async () => {
+  const updatedGroup = await GroupsRepo.updateGroupByID(group.id, null, opts.location);
+  expect(updatedGroup.location).toEqual(opts.location);
+});
+
+test('update group location as admin with null location', async () => {
+  const updatedGroup = await GroupsRepo.updateGroupByID(group.id, null, { lat: null, long: null });
+  expect(updatedGroup.location).toEqual(group.location);
 });
 
 test('leave group', async () => {


### PR DESCRIPTION
- `Group` has two new fields, `location: { lat: ?number, long: ?number }` and `isLocationRestricted: boolean`
- new endpoint `/sessions/:id/location/restriction/` that updates a group's location restriction
- `/start/session/` initializes the group location with the admin's location (lat/long can be null)
- `/join/session/` will update the group's location if the user is an admin, or possibly throw an error if the user is a member and is not within 300 meters of the group's location