### PR TITLE
Change id field for poll

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -291,7 +291,7 @@ export default class GroupSocket {
       });
 
     return {
-      pollID,
+      id: pollID,
       createdAt,
       updatedAt,
       answerChoices: filteredChoices,


### PR DESCRIPTION
When returning a poll in the sockets, the poll object should have field `id` instead of `pollID`