### PR TITLE
Fix userAnswers field when getting group polls

### DIFF
--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -28,6 +28,9 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
     polls.filter(Boolean).forEach((poll) => {
       // date is in Unix time in seconds
       const date = poll.createdAt;
+      const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
+        ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+
       const p = {
         id: poll.id,
         answerChoices: poll.answerChoices,
@@ -37,8 +40,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
         text: poll.text,
         type: poll.type,
         updatedAt: poll.updatedAt,
-        userAnswers: poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-          ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID],
+        userAnswers: userAnswer || [],
       };
       const ind = datesArray.indexOf(date);
       if (ind === -1) { // date not found


### PR DESCRIPTION
Another one, if the user didn't answer the poll, the field `userAnswers` doesn't even appear in the response. So if a user didn't answer the poll, an empty array should be the default value.