### PR TITLE
Fix answerChoice mutability

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -281,14 +281,11 @@ export default class GroupSocket {
     if (!userAnswers) userAnswers = {};
     if (!correctAnswer) correctAnswer = '';
 
-    const filteredChoices = userRole === 'admin'
+    const filteredChoices = userRole === constants.USER_TYPES.ADMIN
     || !isMultipleChoice
     || state === constants.POLL_STATES.SHARED
       ? answerChoices
-      : answerChoices.map((a) => {
-        a.count = null;
-        return a;
-      });
+      : answerChoices.map(a => ({ ...a, count: null }));
 
     return {
       id: pollID,


### PR DESCRIPTION
`count` for each `PollResult` in `answerChoices` was set to `null` in current poll when current poll should not have been updated