### PR TITLE
Fix travis deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,7 @@ env:
   - secure: k30dCmoJZPIc0ixAMU7wLhl0ji4aovSAUGiVWZFcT4vtX2El8tywd35x+iVrn16hnd+0Y/iLjhK9pbs+Co+L4QcAe1bC3arsS1fy3Sk3XmzV4HldfxIDH2MqOutRliqYqruqt0q22If17ISYbjceJ1b98TaIOp0m6wpOlLO9nAl9bvBYYWCaimPfd44HVf2smE1vQl5QdQ21I8dz0kMVsRZFulxrPG3MRjEHoT9ZTkEAAddPA9Y2AvsAqowJ8JXECoCJ5BP2SnzYg+YotKF8Qr8rsM0+GCZJVgzBwq/tsMxmMntKz/FHmR2sLXUbUTQUj41FF4f2EIiX2UC20oQmNCUd3bMfwPtxpr5gFwntFr733QEDQpoOYJKadPLa/Bhv1PF2q4sY8E/2qpTnqQFms0ZqFVrq+yV0peo4F9Z7m/F2DpT1rDkRC2ygqnIv6wKTlIQzuDOmaiwty2S+C3uWLY9s9XdnRaDGLiuto/QqhOndvHZUXLQ3q26L1m9PCL6qUkkiSdzaNufazC9cfRFu2nQOpCisnNWDxMMkqdVxoQRVGjK7TuQ5GORNzOerRdWOYaSuHn7z90tpy/OxTix/r/9LVqR0z6kALSka2K84UiMj1Z8x/G5iUeGYG+oaZIiFRbwKQ0P2c2fqJEm+pOtq1gCW2uaJ8uc3WR/4pjq0N8w=
 deploy:
   provider: script
-  script:
-  - openssl aes-256-cbc -K $encrypted_b9db1102fcfa_key -iv $encrypted_b9db1102fcfa_iv
-    -in server.pem.enc -out server.pem -d
-  - bash docker_push
+  script: bash docker_push
   skip_cleanup: true
   on:
     all_branches: true

--- a/docker_push
+++ b/docker_push
@@ -2,6 +2,7 @@
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker build -t cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT" --no-cache .
 docker push cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"
+openssl aes-256-cbc -K $encrypted_b9db1102fcfa_key -iv $encrypted_b9db1102fcfa_iv -in server.pem.enc -out server.pem -d
 chmod 600 server.pem
 ssh -i server.pem appdev@"$DOMAIN" "cd docker-compose; export IMAGE_TAG='$TRAVIS_COMMIT'; 
     docker stack deploy --compose-file docker-compose.yml the-stack"


### PR DESCRIPTION
- Weird travis syntax where it only allows a single script to run for the deploy section
- Moved the decryption of the server.pem into the docker_push script
- Tested by deploying my own branch on dev since master wasn't previously deployed