### PR TITLE
Include count for ended polls in socket

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -291,7 +291,7 @@ export default class GroupSocket {
 
     const filteredChoices = userRole === constants.USER_TYPES.ADMIN
     || !isMultipleChoice
-    || state === constants.POLL_STATES.SHARED
+    || state !== constants.POLL_STATES.LIVE
       ? answerChoices
       : answerChoices.map(a => ({ ...a, count: null }));
 

--- a/src/routers/v2/swagger.json
+++ b/src/routers/v2/swagger.json
@@ -1822,7 +1822,7 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is MC & poll is not shared"
+          "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is MC & poll is live"
         },
         "letter": {
           "type": "string",
@@ -1857,7 +1857,7 @@
         },
         "answerChoices": {
           "type": "array",
-          "description": "All answers for the poll; count is null if user is `member` and MC question is `live` or `ended`",
+          "description": "All answers for the poll; count is null if user is `member` and MC question is `live`",
           "items": {
             "$ref": "#/definitions/PollResult"
           }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

The `count` property of `answerChoice` in socket polls is `null` for users only for live polls. Previously, `count` was set to `null` for users for both live and ended polls.
