### PR TITLE
Change key pollID to id for event user/poll/results

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -447,7 +447,7 @@ _setupAdminEvents(client: IOSocket): void {
     if (!userAnswers) userAnswers = {};
 
     this.nsp.to('members').emit('user/poll/results', ({
-      pollID, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
+      id: pollID, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
     } : ClientPoll));
   });
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
In a socket poll, the poll ID should be assigned to the key `id` in the `currentPoll`, but was incorrectly set to `pollID` for the event `user/poll/results`. This is fixed now.

</details>
