### PR TITLE
Access correct ID field of group in socket

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -5,7 +5,6 @@ import SocketIO from 'socket.io';
 import constants from './utils/Constants';
 import Group from './models/Group';
 import GroupsRepo from './repos/GroupsRepo';
-import lib from './utils/Lib.js';
 import PollsRepo from './repos/PollsRepo';
 import UserSessionsRepo from './repos/UserSessionsRepo';
 
@@ -101,7 +100,7 @@ export default class GroupSocket {
       return;
     }
 
-    const userType = (await GroupsRepo.isAdmin(this.group.id, user)) ? 'admin' : 'member';
+    const userType = (await GroupsRepo.isAdmin(this.group.uuid, user)) ? 'admin' : 'member';
 
     switch (userType) {
       case 'admin': {

--- a/src/routers/v2/JoinGroupRouter.js
+++ b/src/routers/v2/JoinGroupRouter.js
@@ -3,7 +3,6 @@ import { Request } from 'express';
 import GroupsRepo from '../../repos/GroupsRepo';
 import AppDevRouter from '../../utils/AppDevRouter';
 import constants from '../../utils/Constants';
-import lib from '../../utils/Lib';
 import LogUtils from '../../utils/LogUtils';
 
 import type { APIGroup } from './APITypes';


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
An error is occurring on socket connection where we check whether the user is an admin or not. We pass the incorrect `id` field into the repo function, resulting in `undefined` admins.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Changed `id` to `uuid`. Also removed an unneeded import.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

The unit tests should still work locally, but we need to test with iOS and Android to make sure this fix isn't the only one we'll need since we've switched from `id` to `uuid`.


## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->
#233 



</details>
