### PR TITLE
Remove free response structures and fields

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -9,7 +9,7 @@ import PollsRepo from './repos/PollsRepo';
 import UserSessionsRepo from './repos/UserSessionsRepo';
 
 import type { PollChoice, PollResult } from './models/Poll';
-import type { PollState, PollType } from './utils/Constants';
+import type { PollState } from './utils/Constants';
 
 /** Configuration for each GroupSocket */
 export type GroupSocketConfig = {
@@ -28,25 +28,22 @@ type SocketPoll = {
   id?: id,
   createdAt?: string,
   updatedAt?: string,
-  answers: { string: PollChoice[] }, // {googleID: [PollChoice]} for MC and {googleID: PollChoice[]} for FR
+  answers: { string: PollChoice[] }, // {googleID: [PollChoice]}
   answerChoices: PollResult[],
-  correctAnswer: ?string, // letter of MC PollChoice
+  correctAnswer: ?string, // letter of PollChoice
   state: PollState,
   text: string,
-  type: PollType,
-  upvotes: { string: PollChoice[] } // {} for MC and {googleID: PollChoice[]} for FR
 };
 
 type ClientPoll = {
   id?: id,
-  answerChoices: PollResult[], // count is null if user is 'member' and MC poll is live or ended
+  answerChoices: PollResult[], // count is null if user is 'member' and poll is live
   correctAnswer?: string,
   createdAt?: string,
   state: PollState,
   text: string,
-  type: PollType,
   updatedAt?: string,
-  userAnswers: { string: PollChoice[] } // {googleID: PollChoice[]} of answers for MC and upvotes for FR}
+  userAnswers: { string: PollChoice[] } // {googleID: PollChoice[]} of answers
 };
 
 /**
@@ -138,80 +135,24 @@ export default class GroupSocket {
       return;
     }
 
-    switch (poll.type) {
-      case constants.POLL_TYPES.MULTIPLE_CHOICE: // Multiple Choice
-        if (poll.answers[googleID]) { // User selected something before
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.letter && (p.count !== null) && p.letter === poll.answers[googleID][0].letter) { p.count -= 1; }
-          });
+    if (poll.answers[googleID]) { // User selected something before
+      poll.answerChoices.forEach((p: PollResult) => {
+        if (p.letter && (p.count !== null) && p.letter === poll.answers[googleID][0].letter) {
+          p.count -= 1;
         }
-        // update/add response
-        poll.answers[googleID] = [submittedAnswer];
-        poll.answerChoices.forEach((p: PollResult) => {
-          if (p.letter && (p.count !== null) && p.letter === submittedAnswer.letter) { p.count += 1; }
-        });
-        break;
-      case constants.POLL_TYPES.FREE_RESPONSE: { // Free Response
-        if (poll.answers[googleID]) { // User submitted another FR answer
-          poll.answers[googleID].push(submittedAnswer);
-          poll.upvotes[googleID].push(submittedAnswer);
-        } else { // User submitted first FR answer
-          poll.answers[googleID] = [submittedAnswer];
-          poll.upvotes[googleID] = [submittedAnswer];
-        }
-
-        poll.answerChoices.push({ count: 1, text: submittedAnswer.text, letter: null });
-        break;
-      }
-      default:
-        throw new Error('Unimplemented poll type');
+      });
     }
+    // update/add response
+    poll.answers[googleID] = [submittedAnswer];
+    poll.answerChoices.forEach((p: PollResult) => {
+      if (p.letter && (p.count !== null) && p.letter === submittedAnswer.letter) {
+        p.count += 1;
+      }
+    });
 
     this.current = poll;
 
     this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
-    if (poll.type === constants.POLL_TYPES.FREE_RESPONSE) {
-      this.nsp.to('members').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-    }
-  }
-
-  _upvoteAnswer(client: IOSocket, googleID: string, upvoteObject: PollChoice): void {
-    const { text } = upvoteObject;
-    const poll = this.current;
-    if (!poll || !text) {
-      // console.log(`Client with googleID ${googleID} tried to answer with no active poll`);
-      return;
-    }
-
-    const currAnswer: ?PollResult = poll.answerChoices.find((p: PollResult) => p.text === text);
-    if (currAnswer) { // User selected a valid answer
-      const userUpvotes = poll.upvotes[googleID];
-      if (userUpvotes) { // User upvoted something before
-        if (userUpvotes.find((p: PollChoice) => p.text === text)) { // unupvote
-          poll.upvotes[googleID] = userUpvotes.filter(p => p.text !== text);
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.count !== null && p.text === text) { p.count -= 1; }
-          });
-        } else { // upvote
-          poll.upvotes[googleID].push({ text });
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.count !== null && p.text === text) { p.count += 1; }
-          });
-        }
-      } else { // init array and upvote
-        poll.answerChoices.forEach((p: PollResult) => {
-          if (p.count !== null && p.text === text) { p.count += 1; }
-        });
-        poll.upvotes[googleID] = [{ text }];
-      }
-    }
-
-    this.current = poll;
-
-    this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
-    if (poll.type === constants.POLL_TYPES.FREE_RESPONSE) {
-      this.nsp.to('members').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-    }
   }
 
   // ***************************** User Side ***************************
@@ -222,11 +163,7 @@ export default class GroupSocket {
    * 'server/poll/answer' (PollChoice)
    *  - Client answers current poll
    *  - Adds the answer to answers
-   *  - If poll is free response, then also add to upvotes
    *
-   * 'server/poll/upvote', (PollChoice)
-   *  - Client upvotes an answer or unupvotes if previously upvoted
-   *  - Increases count of answer upvoted or decreases count of answer unupvoted in answerChoices
    * @function
    * @param {IOSocket} client - Client's socket object
    * @param {String} googleID
@@ -234,10 +171,6 @@ export default class GroupSocket {
   _setupUserEvents(client: IOSocket, googleID: string): void {
     client.on('server/poll/answer', (submittedAnswer: PollChoice) => {
       this._answerPoll(client, googleID, submittedAnswer);
-    });
-
-    client.on('server/poll/upvote', (upvoteObject: PollChoice) => {
-      this._upvoteAnswer(client, googleID, upvoteObject);
     });
 
     client.on('disconnect', async () => {
@@ -258,24 +191,17 @@ export default class GroupSocket {
   */
   _currentPoll(userRole: string): ClientPoll | null {
     if (!this.current) return null; // no live poll
-    let { correctAnswer } = this.current;
+
+    let { correctAnswer, answers } = this.current;
     const {
-      createdAt, updatedAt, answers, answerChoices, state, text, type, upvotes,
+      createdAt, updatedAt, answerChoices, state, text,
     } = this.current;
     const pollID = this.current.id;
 
-    let userAnswers;
-    const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
-    if (isMultipleChoice) {
-      userAnswers = answers;
-    } else {
-      userAnswers = upvotes;
-    }
-    if (!userAnswers) userAnswers = {};
+    if (!answers) answers = {};
     if (!correctAnswer) correctAnswer = '';
 
     const filteredChoices = userRole === constants.USER_TYPES.ADMIN
-    || !isMultipleChoice
     || state !== constants.POLL_STATES.LIVE
       ? answerChoices
       : answerChoices.map(a => ({ ...a, count: null }));
@@ -288,8 +214,7 @@ export default class GroupSocket {
       correctAnswer,
       state,
       text,
-      type,
-      userAnswers,
+      userAnswers: answers,
     };
   }
 
@@ -305,9 +230,7 @@ export default class GroupSocket {
       correctAnswer: poll.correctAnswer,
       state: constants.POLL_STATES.LIVE,
       text: poll.text,
-      type: poll.type,
       answers: {},
-      upvotes: {},
     };
 
     this.current = newPoll;
@@ -330,11 +253,9 @@ _endPoll = async () => {
     poll.text,
     this.group,
     poll.answerChoices,
-    poll.type,
     poll.correctAnswer,
     poll.answers,
     poll.state,
-    poll.upvotes,
   );
   this.current = { ...createdPoll };
 
@@ -410,7 +331,7 @@ _setupAdminEvents(client: IOSocket): void {
     // console.log('sharing results');
     // Update poll to 'shared'
     const sharedPoll = await PollsRepo.updatePollByID(
-      pollID, null, null, null, null, constants.POLL_STATES.SHARED,
+      pollID, null, null, null, constants.POLL_STATES.SHARED,
     );
 
     if (!sharedPoll) {
@@ -419,20 +340,14 @@ _setupAdminEvents(client: IOSocket): void {
     }
 
     const {
-      createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text, type, upvotes,
+      createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text,
     } = sharedPoll;
 
-    let userAnswers;
-    const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
-    if (isMultipleChoice) {
-      userAnswers = answers;
-    } else {
-      userAnswers = upvotes;
-    }
+    let userAnswers = answers;
     if (!userAnswers) userAnswers = {};
 
     this.nsp.to('members').emit('user/poll/results', ({
-      id: pollID, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
+      id: pollID, createdAt, updatedAt, answerChoices, correctAnswer, state, text, userAnswers,
     } : ClientPoll));
   });
 

--- a/src/db/migrations/1573839312713-removefr.js
+++ b/src/db/migrations/1573839312713-removefr.js
@@ -1,0 +1,19 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class removefr1573839312713 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner
+            .query('ALTER TABLE "polls" DROP COLUMN "type"');
+        await queryRunner
+            .query('ALTER TABLE "polls" DROP COLUMN "upvotes"');
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner
+            .query('ALTER TABLE "polls" ADD COLUMN "type" varchar');
+            await queryRunner
+            .query('ALTER TABLE "polls" ADD COLUMN "upvotes" json');
+    }
+
+}

--- a/src/models/Draft.js
+++ b/src/models/Draft.js
@@ -25,7 +25,7 @@ class Draft extends Base {
   @Column('character varying')
   text: string = '';
 
-  /** Options of question, empty for FR */
+  /** Options of question */
   @Column('json')
   options: string[] = undefined;
 

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -10,18 +10,18 @@ import Base from './Base';
 import Group from './Group';
 
 import type { APIPoll } from '../routers/v2/APITypes';
-import type { PollType, PollState } from '../utils/Constants';
+import type { PollState } from '../utils/Constants';
 
 import constants from '../utils/Constants';
 
 export type PollResult = {|
-  letter: ?string,
+  letter: string,
   text: string,
   count: ?number,
 |}
 
 export type PollChoice = {|
-  letter: ?string,
+  letter: string,
   text: string,
 |}
 
@@ -39,10 +39,6 @@ class Poll extends Base {
   @Column('character varying')
   text: string = '';
 
-  /** Type of poll either multipleChoice or freeResponse */
-  @Column('character varying')
-  type: PollType = constants.POLL_TYPES.MULTIPLE_CHOICE;
-
   /** Group the poll belongs to */
   @ManyToOne(type => Group, group => group.polls, { onDelete: 'CASCADE' })
   group: ?Group = null;
@@ -50,8 +46,7 @@ class Poll extends Base {
   /**
    * Choices for the poll
    * @example
-   * let answerChoices_mc = [{letter: "A", text: "Saturn", count: 5}]
-   * let answerChoices_fr = [{text: "Saturn", count: 10}]
+   * let answerChoices = [{letter: "A", text: "Saturn", count: 5}]
    */
   @Column('json')
   answerChoices: PollResult[] = undefined;
@@ -60,24 +55,14 @@ class Poll extends Base {
    * All the answers by students for the poll.
    * Letter field is optional and only is returned on MC polls.
    * @example
-   * let answers_MC = {googleID: [{letter: "A", text: "Saturn"}]}
-   * let answers_FR = {googleID: [{text: "Saturn"}, {text: "Mars"}]}
+   * let answers = {googleID: [{letter: "A", text: "Saturn"}]}
    */
   @Column('json')
   answers: { string: PollChoice[] } = {};
 
   /**
-   * All the upvotes by students for the FR poll. Empty if MC.
-   * @example
-   * let upvotes_MC = {}
-   * let upvotes_FR = {googleID: [{text: "Saturn"}, {text: "Mars"}]}
-   */
-  @Column('json')
-  upvotes: { string: PollChoice[] } = {};
-
-  /**
    * Correct answer choice for MC.
-   * Empty string if FR or no correct answer chosen for MC.
+   * Empty string if no correct answer chosen for MC.
    * @example
    * let correctAnswer = 'A'
   */
@@ -96,7 +81,6 @@ class Poll extends Base {
       correctAnswer: this.correctAnswer,
       state: this.state,
       text: this.text,
-      type: this.type,
       userAnswers: this.answers,
     };
   }

--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -321,7 +321,7 @@ const getUsersByGroupID = async (id: string, role: ?string):
 
 /**
  * Gets polls from a group sorted by creation date in ascending order.
- * By default will hide poll results if poll is not shared.
+ * By default will hide poll results if poll is live.
  * @function
  * @param {string} id - UUID of group to fetch polls from
  * @param {boolean} hideUnsharedResults - Whether to return unaltered poll results for admins
@@ -336,11 +336,10 @@ const getPolls = async (id: string, hideUnsharedResults: ?boolean = true):
       .setParameters({ groupID: id })
       .orderBy('polls.createdAt', 'ASC')
       .getOne();
-    // obscure poll results if poll not shared
+    // obscure poll results if poll is live
     return group.polls.map((poll) => {
       if (
-        hideUnsharedResults && poll.state !== constants.POLL_STATES.SHARED
-        && poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
+        hideUnsharedResults && poll.state === constants.POLL_STATES.LIVE
       ) {
         poll.answerChoices = poll.answerChoices.map((choice) => {
           delete choice.count;

--- a/src/repos/PollsRepo.js
+++ b/src/repos/PollsRepo.js
@@ -5,7 +5,7 @@ import Poll from '../models/Poll';
 import LogUtils from '../utils/LogUtils';
 
 import type { PollChoice, PollResult } from '../models/Poll';
-import type { PollType, PollState } from '../utils/Constants';
+import type { PollState } from '../utils/Constants';
 
 const db = (): Repository<Poll> => getRepository(Poll);
 
@@ -15,22 +15,18 @@ const db = (): Repository<Poll> => getRepository(Poll);
  * @param {string} text - Text of poll
  * @param {Group} group - Group that the poll belongs to
  * @param {PollResult[]} answerChoices - the answer choices for the given poll
- * @param {string} type - Type of poll, see Poll class for more info
  * @param {string} correctAnswer - Correct answer choice for MC
  * @param {string: PollChoice[]} answers - answers given from students
  * @param {PollState} state - the current state of the poll
- * @param {string: PollChoice[]} upvotes - upvotes given from students
  * @return {Poll} New poll created
  */
 const createPoll = async (
   text: string,
   group: ?Group,
   answerChoices: PollResult[],
-  type: PollType,
   correctAnswer: ?string,
   answers: ?{ string: PollChoice[] },
   state: PollState,
-  upvotes: ?{ string: PollChoice[] },
 ): Promise<Poll> => {
   try {
     const poll = new Poll();
@@ -38,10 +34,8 @@ const createPoll = async (
     poll.correctAnswer = correctAnswer || '';
     poll.state = state;
     poll.text = text;
-    poll.type = type;
     if (group) poll.group = group;
     if (answers) poll.answers = answers;
-    if (upvotes) poll.upvotes = upvotes;
     await db().save(poll);
     return poll;
   } catch (e) {
@@ -50,11 +44,9 @@ const createPoll = async (
       text,
       group,
       answerChoices,
-      type,
       correctAnswer,
       answers,
       state,
-      upvotes,
     });
   }
 };
@@ -97,12 +89,11 @@ const deletePollByID = async (id: string) => {
  * @param {?string} [text] - new text for poll
  * @param {?PollResult[]} answerChoices - the answer choices for the given poll
  * @param {string: PollChoice[]} [answers] - the students answers to the poll
- * @param {string: PollChoice[]} [upvotes] - upvotes from students
  * @param {PollState} [state] - the state of the poll
  * @return {?Poll} Updated poll
  */
 const updatePollByID = async (id: string, text: ?string, answerChoices: ?PollResult[],
-  answers: ?{string: PollChoice[]}, upvotes: ?{string: PollChoice[]}, state: ?PollState):
+  answers: ?{string: PollChoice[]}, state: ?PollState):
   Promise<?Poll> => {
   try {
     const poll = await db().createQueryBuilder('polls')
@@ -113,7 +104,6 @@ const updatePollByID = async (id: string, text: ?string, answerChoices: ?PollRes
     if (text !== undefined && text !== null) poll.text = text;
     if (answerChoices) poll.answerChoices = answerChoices;
     if (answers) poll.answers = answers;
-    if (upvotes) poll.upvotes = upvotes;
     if (state) poll.state = state;
     await db().save(poll);
     return poll;

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -1,5 +1,5 @@
 // @flow
-import type { PollChoice, PollState, PollType } from '../../utils/Constants';
+import type { PollChoice, PollState } from '../../utils/Constants';
 import type { PollResult } from '../../models/Poll';
 
 // *********************** GENERAL RESPONSE TYPES ***********************
@@ -29,7 +29,6 @@ export type APIPoll = {|
   correctAnswer: string,
   state: PollState,
   text: string,
-  type: PollType,
   userAnswers: { string: PollChoice[] },
 |}
 

--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -28,8 +28,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
     polls.filter(Boolean).forEach((poll) => {
       // date is in Unix time in seconds
       const date = poll.createdAt;
-      const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-        ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+      const userAnswer = poll.answers[req.user.googleID];
       const answerObject = {};
       answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/Polls/GetPollRouter.js
+++ b/src/routers/v2/Polls/GetPollRouter.js
@@ -28,16 +28,14 @@ class GetPollRouter extends AppDevRouter<APIPoll> {
 
     const isAdmin = await GroupsRepo.isAdmin(group.uuid, req.user);
 
-    if (!isAdmin && poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      && poll.state !== constants.POLL_STATES.SHARED) {
+    if (!isAdmin && poll.state === constants.POLL_STATES.LIVE) {
       poll.answerChoices = poll.answerChoices.map((answer) => {
         delete answer.count;
         return answer;
       });
     }
 
-    const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+    const userAnswer = poll.answers[req.user.googleID];
     const answerObject: { string: PollChoice[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/Polls/UpdatePollRouter.js
+++ b/src/routers/v2/Polls/UpdatePollRouter.js
@@ -21,11 +21,11 @@ class UpdatePollRouter extends AppDevRouter<APIPoll> {
   async content(req: Request) {
     const pollID = req.params.id;
     const {
-      text, answerChoices, state, answers, upvotes,
+      text, answerChoices, state, answers,
     } = req.body;
     const { user } = req;
 
-    if (!answerChoices && !text && !state && !answers && !upvotes) {
+    if (!answerChoices && !text && !state && !answers) {
       throw LogUtils.logErr('No fields specified to update');
     }
 
@@ -38,14 +38,12 @@ class UpdatePollRouter extends AppDevRouter<APIPoll> {
       );
     }
 
-    const poll = await PollsRepo.updatePollByID(pollID, text,
-      answerChoices, answers, upvotes, state);
+    const poll = await PollsRepo.updatePollByID(pollID, text, answerChoices, answers, state);
     if (!poll) {
       throw LogUtils.logErr(`Poll with UUID ${pollID} was not found`);
     }
 
-    const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+    const userAnswer = poll.answers[req.user.googleID];
     const answerObject: { string: PollChoice[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/swagger.json
+++ b/src/routers/v2/swagger.json
@@ -1309,28 +1309,10 @@
           "Socket: to server"
         ],
         "summary": "Answer a poll",
-        "description": "User sends this to answer a multiple choice poll or submit a FR answer",
+        "description": "User sends this to answer a poll",
         "parameters": [
           {
             "name": "submittedAnswer",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/PollChoice"
-            }
-          }
-        ]
-      }
-    },
-    "server/poll/upvote": {
-      "get": {
-        "tags": [
-          "Socket: to server"
-        ],
-        "summary": "Upvote a FR answer",
-        "description": "User sends this to upvote an answer in free response",
-        "parameters": [
-          {
-            "name": "upvotedAnswer",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/PollChoice"
@@ -1413,22 +1395,6 @@
         ],
         "summary": "User receives to display a poll",
         "description": "State should be “live”",
-        "responses": [
-          {
-            "name": "currentPoll",
-            "schema": {
-              "$ref": "#/definitions/Socket - ClientPoll"
-            }
-          }
-        ]
-      }
-    },
-    "user/poll/fr/live": {
-      "get": {
-        "tags": [
-          "Socket: to member"
-        ],
-        "summary": "User receives an updated poll to reflect the current changes (only FR)",
         "responses": [
           {
             "name": "currentPoll",
@@ -1568,7 +1534,7 @@
         },
         "options": {
           "type": "array",
-          "description": "Poll options, empty if FR",
+          "description": "Poll options",
           "items": {
             "type": "string"
           }
@@ -1641,18 +1607,14 @@
           "example": [
             {
               "letter": "A",
-              "text": "MC example",
+              "text": "example",
               "count": 5
-            },
-            {
-              "text": "FR example",
-              "count": 16
             }
           ]
         },
         "correctAnswer": {
           "type": "string",
-          "description": "Letter of correct answer choice (MC only)",
+          "description": "Letter of correct answer choice",
           "example": "A"
         },
         "createdAt": {
@@ -1674,15 +1636,6 @@
           "description": "Poll question",
           "example": "Which planet is a gas giant?"
         },
-        "type": {
-          "type": "string",
-          "description": "Poll type",
-          "enum": [
-            "multipleChoice",
-            "freeResponse"
-          ],
-          "example": "multipleChoice"
-        },
         "updatedAt": {
           "type": "string",
           "description": "Timestamp (Unix time)",
@@ -1690,7 +1643,7 @@
         },
         "userAnswers": {
           "type": "object",
-          "description": "Mapping of googleID to the choice the user selected if MC, or the choices the user upvoted if FR",
+          "description": "Mapping of googleID to the choice the user selected",
           "properties": {
             "googleID(string)": {
               "type": "array",
@@ -1700,16 +1653,8 @@
               "example": {
                 "googleID1": {
                   "letter": "A",
-                  "text": "selected MC answer"
-                },
-                "googleID2": [
-                  {
-                    "text": "upvoted FR answer1"
-                  },
-                  {
-                    "text": "upvoted FR answer2"
-                  }
-                ]
+                  "text": "selected answer"
+                }
               }
             }
           }
@@ -1722,7 +1667,6 @@
         "createdAt",
         "state",
         "text",
-        "type",
         "updatedAt",
         "userAnswers"
       ]
@@ -1732,7 +1676,7 @@
       "properties": {
         "letter": {
           "type": "string",
-          "description": "Letter identifier of answer choice (MC only)",
+          "description": "Letter identifier of answer choice",
           "example": "A",
           "nullable": true
         },
@@ -1752,14 +1696,13 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is MC & poll is live",
+          "description": "Number of times choice was selected <br/>`Null` when user is member & poll is live",
           "nullable": true
         },
         "letter": {
           "type": "string",
-          "description": "Letter identifier of answer choice (MC only)",
-          "example": "A",
-          "nullable": true
+          "description": "Letter identifier of answer choice",
+          "example": "A"
         },
         "text": {
           "type": "string",
@@ -1781,7 +1724,7 @@
         },
         "answerChoices": {
           "type": "array",
-          "description": "All answers for the poll; count is null if user is `member` and MC poll is `live`",
+          "description": "All answers for the poll; count is null if user is `member` and poll is `live`",
           "items": {
             "$ref": "#/definitions/PollResult"
           }
@@ -1789,7 +1732,7 @@
         "correctAnswer": {
           "type": "string",
           "example": "A",
-          "description": "Letter of correct answer choice (MC only)"
+          "description": "Letter of correct answer choice"
         },
         "createdAt": {
           "type": "string",
@@ -1809,14 +1752,6 @@
           "type": "string",
           "description": "Poll question"
         },
-        "type": {
-          "type": "string",
-          "description": "Poll type",
-          "enum": [
-            "multipleChoice",
-            "freeResponse"
-          ]
-        },
         "updatedAt": {
           "type": "string",
           "description": "Timestamp (Unix time)",
@@ -1824,7 +1759,7 @@
         },
         "userAnswers": {
           "type": "object",
-          "description": "Mapping of googleID to user answers for MC and upvotes for FR",
+          "description": "Mapping of googleID to user answers",
           "properties": {
             "googleID(string)": {
               "type": "array",
@@ -1834,16 +1769,8 @@
               "example": {
                 "googleID1": {
                   "letter": "A",
-                  "text": "selected MC answer"
-                },
-                "googleID2": [
-                  {
-                    "text": "upvoted FR answer1"
-                  },
-                  {
-                    "text": "upvoted FR answer2"
-                  }
-                ]
+                  "text": "selected answer"
+                }
               }
             }
           }

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -27,16 +27,6 @@ const POLL_STATES = {
 };
 
 /**
-* constants for question types
-* @constant
-* @enum {string}
-*/
-const POLL_TYPES = {
-  MULTIPLE_CHOICE: 'multipleChoice',
-  FREE_RESPONSE: 'freeResponse',
-};
-
-/**
 * constants for user types
 * @constant
 * @enum {string}
@@ -48,11 +38,9 @@ const USER_TYPES = {
 
 /** Custom types for Poll type */
 export type PollState = 'live' | 'ended' | 'shared'
-export type PollType = 'multipleChoice' | 'freeResponse'
 
 export default {
   POLL_STATES,
-  POLL_TYPES,
   REQUEST_TYPES,
   USER_TYPES,
 };

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -183,17 +183,18 @@ test('Get Polls from Group', async () => {
   expect(polls.length).toEqual(0);
 
   const answerChoices1 = [{ letter: 'A', text: 'blue', count: 1 }];
-  const answerChoices2 = [{ text: 'blue', count: 0 }, { text: 'red', count: 2 }];
+  const answerChoices2 = [{ letter: 'A', text: 'blue', count: 0 }, { letter: 'B', text: 'red', count: 2 }];
   const answerChoices1WithoutCounts = [{ letter: 'A', text: 'blue' }];
+  const answerChoices2WithoutCounts = [{ letter: 'A', text: 'blue' }, { letter: 'B', text: 'red' }];
 
-  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, 'multipleChoice', '', null, 'ended');
-  const poll2 = await PollsRepo.createPoll('', group, answerChoices2, 'freeResponse', '', null, 'ended');
-  polls = await GroupsRepo.getPolls(uuid);
+  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, '', null, 'live');
+  const poll2 = await PollsRepo.createPoll('', group, answerChoices2, '', null, 'live');
+  polls = await GroupsRepo.getPolls(uuid, true);
   expect(polls.length).toEqual(2);
   expect(polls[0].uuid).toBe(poll.uuid);
   expect(polls[1].uuid).toBe(poll2.uuid);
   expect(polls[0].answerChoices).toEqual(answerChoices1WithoutCounts);// if member, hide results
-  expect(polls[1].answerChoices).toEqual(answerChoices2);
+  expect(polls[1].answerChoices).toEqual(answerChoices2WithoutCounts);
   polls = await GroupsRepo.getPolls(uuid, false); // if admin, don't hide results
   expect(polls[0].answerChoices).toEqual(answerChoices1);
   expect(polls[1].answerChoices).toEqual(answerChoices2);

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -24,27 +24,22 @@ beforeAll(async () => {
 });
 
 test('Create Poll', async () => {
-  const poll = await PollsRepo
-    .createPoll('Poll', group, [], 'multipleChoice', 'A', null, 'shared', {});
+  const poll = await PollsRepo.createPoll('Poll', group, [], 'A', null, 'shared');
   expect(poll.text).toBe('Poll');
   expect(poll.group.id).toBe(group.id);
   expect(poll.answerChoices).toEqual([]);
-  expect(poll.type).toBe('multipleChoice');
   expect(poll.correctAnswer).toBe('A');
   expect(poll.state).toBe('shared');
   expect(poll.answers).toEqual({});
-  expect(poll.upvotes).toEqual({});
   ({ uuid } = poll);
 
-  const poll2 = await PollsRepo.createPoll('', group, [], 'freeResponse', null, {}, 'ended', {});
+  const poll2 = await PollsRepo.createPoll('', group, [], '', null, 'ended');
   expect(poll2.text).toBe('');
   expect(poll2.group.id).toBe(group.id);
   expect(poll2.answerChoices).toEqual([]);
-  expect(poll2.type).toBe('freeResponse');
   expect(poll2.correctAnswer).toBe('');
   expect(poll2.state).toBe('ended');
   expect(poll2.answers).toEqual({});
-  expect(poll2.upvotes).toEqual({});
   uuid2 = poll2.uuid;
 });
 
@@ -52,16 +47,14 @@ test('Get Poll', async () => {
   const poll = await PollsRepo.getPollByID(uuid);
   expect(poll.text).toBe('Poll');
   expect(poll.state).toBe('shared');
-  expect(poll.type).toBe('multipleChoice');
 
   const poll2 = await PollsRepo.getPollByID(uuid2);
   expect(poll2.text).toBe('');
   expect(poll2.state).toBe('ended');
-  expect(poll2.type).toBe('freeResponse');
 });
 
 test('Update Poll', async () => {
-  const poll = await PollsRepo.updatePollByID(uuid, 'New Poll', null, null, null, 'ended');
+  const poll = await PollsRepo.updatePollByID(uuid, 'New Poll', null, null, 'ended');
   expect(poll.text).toBe('New Poll');
   expect(poll.state).toBe('ended');
 
@@ -77,7 +70,7 @@ test('Get Group from Poll', async () => {
 
 test('Get Polls from Group', async () => {
   await PollsRepo
-    .createPoll('Another poll', group, [], 'freeResponse', null, null, 'ended', null);
+    .createPoll('Another poll', group, [], null, null, 'ended');
   const polls = await GroupsRepo.getPolls(group.uuid);
   expect(polls.length).toBe(3);
 });

--- a/test/routes/api.poll.test.js
+++ b/test/routes/api.poll.test.js
@@ -36,7 +36,7 @@ beforeAll(async () => {
   group = result.data;
 
   poll = await PollsRepo.createPoll('Poll text', await GroupsRepo.getGroupByID(group.id),
-    [{ letter: 'A', text: 'Saturn' }], 'multipleChoice', 'A', null, 'ended', {});
+    [{ letter: 'A', text: 'Saturn' }], 'A', null, 'ended');
 
   expect(result.success).toBe(true);
 });


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

The MVP does not include support for free response polls. This PR removes all free response associated fields and socket events. Documentation is updated accordingly.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

API Poll
`type` - removed

Draft
`options: string[]` - will no longer be empty for FR

Poll (Types)
`PollType` - type removed
`PollResult` - `letter` is no longer optional
`PollChoice` - `letter` is no longer optional

Poll (Fields)
`upvotes` - removed
`answerChoices: PollResult[]` - see `PollResult`
`answers: { googleID : PollChoice[] }`  - see `PollChoice`
`correctAnswer` - no behavioral changes, just won’t be empty string if FR

SocketPoll
`type` - removed
`upvotes` - removed
`answers` - will be `{ googleID : PollChoice }` instead of `PollChoice[]`

ClientPoll
`type` - removed
`upvotes` - removed

Socket
`user/poll/fr/live` - event removed
`server/poll/upvote` - event removed


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

I updated some of the test cases that tested free response polls specifically. Otherwise, the unit tests all passed.


## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->

#239 

