### PR TITLE
Keep currentPoll consistent with SocketPoll

### DIFF
--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -336,7 +336,7 @@ _endPoll = async () => {
     poll.state,
     poll.upvotes,
   );
-  this.current = { ...createdPoll };
+  this.current = { ...createdPoll, id: createdPoll.uuid };
 
   this.nsp.to('admins').emit('admin/poll/ended', this._currentPoll(constants.USER_TYPES.ADMIN));
   this.nsp.to('members').emit('user/poll/end', this._currentPoll(constants.USER_TYPES.MEMBER));
@@ -407,7 +407,6 @@ _setupAdminEvents(client: IOSocket): void {
 
   // share results
   client.on('server/poll/results', async (pollID: id) => {
-    // console.log('sharing results');
     // Update poll to 'shared'
     const sharedPoll = await PollsRepo.updatePollByID(
       pollID, null, null, null, null, constants.POLL_STATES.SHARED,
@@ -419,7 +418,7 @@ _setupAdminEvents(client: IOSocket): void {
     }
 
     const {
-      createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text, type, upvotes,
+      uuid, createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text, type, upvotes,
     } = sharedPoll;
 
     let userAnswers;
@@ -432,7 +431,7 @@ _setupAdminEvents(client: IOSocket): void {
     if (!userAnswers) userAnswers = {};
 
     this.nsp.to('members').emit('user/poll/results', ({
-      id: pollID, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
+      id: uuid, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
     } : ClientPoll));
   });
 

--- a/test/repos/draft.test.js
+++ b/test/repos/draft.test.js
@@ -40,25 +40,25 @@ test('Get Draft', async () => {
   const temp = await DraftsRepo.getDraft(draft1.uuid);
   expect(temp.text).toBe(draft1.text);
   expect(temp.options).toEqual(draft1.options);
-  expect(temp.user.id).toEqual(draft1.user.id);
+  expect(temp.user.uuid).toEqual(draft1.user.uuid);
 
   const temp2 = await DraftsRepo.getDraft(draft2.uuid);
   expect(temp2.text).toBe(draft2.text);
   expect(temp2.options).toEqual(draft2.options);
-  expect(temp2.user.id).toEqual(draft2.user.id);
+  expect(temp2.user.uuid).toEqual(draft2.user.uuid);
 
   const temp3 = await DraftsRepo.getDraft(draft3.uuid);
   expect(temp3.text).toBe(draft3.text);
   expect(temp3.options).toEqual(draft3.options);
-  expect(temp3.user.id).toEqual(draft3.user.id);
+  expect(temp3.user.uuid).toEqual(draft3.user.uuid);
 });
 
 test('Get Drafts from User', async () => {
   const drafts = await DraftsRepo.getDraftsByUser(user1.uuid);
   expect(drafts.length).toBe(3);
-  expect(drafts[0].id).toBe(draft1.id);
-  expect(drafts[1].id).toBe(draft2.id);
-  expect(drafts[2].id).toBe(draft3.id);
+  expect(drafts[0].uuid).toBe(draft1.uuid);
+  expect(drafts[1].uuid).toBe(draft2.uuid);
+  expect(drafts[2].uuid).toBe(draft3.uuid);
 
   const drafts2 = await DraftsRepo.getDraftsByUser(user2.uuid);
   expect(drafts2.length).toBe(0);
@@ -68,19 +68,19 @@ test('Update Draft', async () => {
   const newDraft = await DraftsRepo.updateDraft(draft1.uuid, 'New Question', []);
   expect(newDraft.text).toBe('New Question');
   expect(newDraft.options).toEqual([]);
-  expect(newDraft.id).toBe(draft1.id);
+  expect(newDraft.uuid).toBe(draft1.uuid);
   draft1 = newDraft;
 
   const newDraft2 = await DraftsRepo.updateDraft(draft2.uuid, '', ['hi', 'hello']);
   expect(newDraft2.text).toBe('');
   expect(newDraft2.options).toEqual(['hi', 'hello']);
-  expect(newDraft2.id).toBe(draft2.id);
+  expect(newDraft2.uuid).toBe(draft2.uuid);
   draft2 = newDraft2;
 });
 
 test('Get Owner of Draft', async () => {
   const user = await DraftsRepo.getOwnerByID(draft1.uuid);
-  expect(user.id).toBe(user1.id);
+  expect(user.uuid).toBe(user1.uuid);
 });
 
 test('Delete Draft', async () => {

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -27,7 +27,7 @@ test('Create Poll', async () => {
   const poll = await PollsRepo
     .createPoll('Poll', group, [], 'multipleChoice', 'A', null, 'shared', {});
   expect(poll.text).toBe('Poll');
-  expect(poll.group.id).toBe(group.id);
+  expect(poll.group.uuid).toBe(group.uuid);
   expect(poll.answerChoices).toEqual([]);
   expect(poll.type).toBe('multipleChoice');
   expect(poll.correctAnswer).toBe('A');
@@ -38,7 +38,7 @@ test('Create Poll', async () => {
 
   const poll2 = await PollsRepo.createPoll('', group, [], 'freeResponse', null, {}, 'ended', {});
   expect(poll2.text).toBe('');
-  expect(poll2.group.id).toBe(group.id);
+  expect(poll2.group.uuid).toBe(group.uuid);
   expect(poll2.answerChoices).toEqual([]);
   expect(poll2.type).toBe('freeResponse');
   expect(poll2.correctAnswer).toBe('');
@@ -72,7 +72,7 @@ test('Update Poll', async () => {
 
 test('Get Group from Poll', async () => {
   const p = await PollsRepo.getGroupFromPollID(uuid);
-  expect(p.id).toBe(group.id);
+  expect(p.uuid).toBe(group.uuid);
 });
 
 test('Get Polls from Group', async () => {

--- a/test/repos/user.test.js
+++ b/test/repos/user.test.js
@@ -111,9 +111,9 @@ test('Get Groups', async () => {
   const memberGroups2 = await UsersRepo.getGroupsByID(uuid, 'member');
   expect(allGroups.length).toEqual(2);
   expect(adminGroups2.length).toEqual(1);
-  expect(adminGroups2[0].id).toBe(group2.id);
+  expect(adminGroups2[0].uuid).toBe(group2.uuid);
   expect(memberGroups2.length).toEqual(1);
-  expect(memberGroups2[0].id).toBe(group.id);
+  expect(memberGroups2[0].uuid).toBe(group.uuid);
 
   await GroupsRepo.deleteGroupByID(group.uuid);
   await GroupsRepo.deleteGroupByID(group2.uuid);


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
`SocketPoll` requires an `id` when a poll is ended or shared, but the field `uuid` was being set instead. This is fixed. In addition, various `draft` repo tests were incorrectly using `id` instead of `uuid`, resulting in tests that pass because `undefined === undefined`. 


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
When `id` is assigned when a poll is ended, `id` and not `uuid` should be reflected in the current poll.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Ran unit tests and tested the current iOS build with the local server.


## Next Steps (delete if not applicable)

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

I will continue to be on the lookout for overlooked `id` and `uuid` mishaps.


## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->
#233 
