### PR TITLE
Fix bug with sessions and users

### DIFF
--- a/src/repos/UserSessionsRepo.js
+++ b/src/repos/UserSessionsRepo.js
@@ -21,15 +21,17 @@ const createOrUpdateSession = async (
   accessToken: ?string,
   refreshToken: ?string,
 ): Promise<UserSession> => {
-  const optionalSession = await db().createQueryBuilder('usersessions')
+  let session = await db().createQueryBuilder('usersessions')
     .innerJoin('usersessions.user', 'user', 'user.uuid = :userID')
     .setParameters({ userID: user.uuid })
     .getOne();
-  return db().save(
-    optionalSession
-      ? optionalSession.update(accessToken, refreshToken)
-      : UserSession.fromUser(user, accessToken, refreshToken),
-  );
+  if (session) {
+    session.update(accessToken, refreshToken);
+    session.user = user;
+  } else {
+    session = UserSession.fromUser(user, accessToken, refreshToken);
+  }
+  return db().save(session);
 };
 
 /**


### PR DESCRIPTION
## Overview
There was an issue that sometimes would come up where a session would not have a user associated with it. I found out that this didn't happen on the first time a session is created but only when it was updated. I had iOS try out these changes and it seemed to work.

## Changes Made
Make sure the user stayed attached to the session

## Test Coverage
I deployed on the dev server and had iOS test it out.

## Next Steps (delete if not applicable)

Make sure that this doesn't happen anywhere else.