### PR TITLE
Deprecated Generate Code Router

### DIFF
--- a/src/routers/v2/GenerateCodeRouter.js
+++ b/src/routers/v2/GenerateCodeRouter.js
@@ -8,6 +8,7 @@ class GenerateCodeRouter extends AppDevRouter<Object> {
     super(constants.REQUEST_TYPES.GET);
   }
 
+  //
   getPath(): string {
     return '/generate/code/';
   }

--- a/src/routers/v2/GenerateCodeRouter.js
+++ b/src/routers/v2/GenerateCodeRouter.js
@@ -8,7 +8,7 @@ class GenerateCodeRouter extends AppDevRouter<Object> {
     super(constants.REQUEST_TYPES.GET);
   }
 
-  //
+  // deprecated, do not use
   getPath(): string {
     return '/generate/code/';
   }

--- a/src/routers/v2/Groups/PostGroupRouter.js
+++ b/src/routers/v2/Groups/PostGroupRouter.js
@@ -18,11 +18,11 @@ class PostGroupRouter extends AppDevRouter<APIGroup> {
 
   async content(req: Request) {
     let { name } = req.body;
-    const { user, body: { code } } = req;
+    const { user } = req;
+    const code = GroupsRepo.createCode();
 
     if (!name) name = '';
     if (!user) throw LogUtils.logErr('User missing');
-    if (!code) throw LogUtils.logErr('Group code missing');
 
     const group = await GroupsRepo.createGroup(name, code, user);
 

--- a/src/routers/v2/StartGroupRouter.js
+++ b/src/routers/v2/StartGroupRouter.js
@@ -3,7 +3,6 @@ import { Request } from 'express';
 import GroupsRepo from '../../repos/GroupsRepo';
 import AppDevRouter from '../../utils/AppDevRouter';
 import constants from '../../utils/Constants';
-import LogUtils from '../../utils/LogUtils';
 
 import type { APIGroup } from './APITypes';
 
@@ -17,13 +16,10 @@ class StartGroupRouter extends AppDevRouter<APIGroup> {
   }
 
   async content(req: Request) {
-    const { code } = req.body;
+    const code = GroupsRepo.createCode();
     let { name } = req.body;
 
     if (!name) name = '';
-    if (!code) {
-      throw LogUtils.logErr('Code required');
-    }
 
     const group = await GroupsRepo.createGroup(name, code, req.user);
     await req.app.groupManager.startNewGroup(group);

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -14,7 +14,7 @@ const {
 // Groups
 // Must be running server to test
 
-const opts = () => ({ name: 'Test group', code: GroupsRepo.createCode() });
+const opts = () => ({ name: 'Test group' });
 const googleID = 'usertest';
 let adminToken;
 let userToken;


### PR DESCRIPTION


<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Generates group code in PostGroupRouter.js and StartGroupRouter.js instead of going through GenerateCodeRouter.js.

Updated test cases to match


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Removed "code" pattern match from the routers and instead replaced them with "const code = GroupsRepo.createCode();" so that users cannot input their own codes.

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Removed the code variable from "opts()" in the groups router api test file and checked to see if all tests still worked; they did.

## Related PRs or Issues (delete if not applicable)

<!-- List related PRs against other branches/repositories. -->
Eventually iOS, Android, and Web will want to update their code to stop calling generate code, but that is only for optimization; this shouldn't conflict with their current implementation.