### PR TITLE
Free Response API changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,7 +2256,7 @@
         },
         "sax": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
           "dev": true
         },
@@ -4202,7 +4202,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -9616,7 +9616,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9893,7 +9893,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10965,7 +10965,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "requires": {
         "through": "2"
       }

--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -137,7 +137,7 @@ export default class GroupSocket {
 
     if (poll.answers[googleID]) { // User selected something before
       poll.answerChoices.forEach((p: PollResult) => {
-        if ((p.letter !== null) && (p.count !== null) && p.letter === poll.answers[googleID][0]) { 
+        if ((p.index !== null) && (p.count !== null) && p.index === poll.answers[googleID][0]) {
           p.count -= 1;
         }
       });
@@ -145,7 +145,7 @@ export default class GroupSocket {
     // update/add response
     poll.answers[googleID] = [submittedAnswer]; // only have one answer at a time
     poll.answerChoices.forEach((p: PollResult) => {
-      if ((p.letter !== null) && (p.count !== null) && p.letter === submittedAnswer) {
+      if ((p.index !== null) && (p.count !== null) && p.index === submittedAnswer) {
         p.count += 1;
       }
     });

--- a/src/GroupSocket.js
+++ b/src/GroupSocket.js
@@ -9,7 +9,7 @@ import PollsRepo from './repos/PollsRepo';
 import UserSessionsRepo from './repos/UserSessionsRepo';
 
 import type { PollChoice, PollResult } from './models/Poll';
-import type { PollState, PollType } from './utils/Constants';
+import type { PollState } from './utils/Constants';
 
 /** Configuration for each GroupSocket */
 export type GroupSocketConfig = {
@@ -28,25 +28,22 @@ type SocketPoll = {
   id?: id,
   createdAt?: string,
   updatedAt?: string,
-  answers: { string: PollChoice[] }, // {googleID: [PollChoice]} for MC and {googleID: PollChoice[]} for FR
+  answers: { string: PollChoice[] }, // {googleID: [PollChoice]}
   answerChoices: PollResult[],
-  correctAnswer: ?string, // letter of MC PollChoice
+  correctAnswer: ?string, // letter of PollChoice
   state: PollState,
   text: string,
-  type: PollType,
-  upvotes: { string: PollChoice[] } // {} for MC and {googleID: PollChoice[]} for FR
 };
 
 type ClientPoll = {
   id?: id,
-  answerChoices: PollResult[], // count is null if user is 'member' and MC poll is live or ended
+  answerChoices: PollResult[], // count is null if user is 'member' and poll is live or ended
   correctAnswer?: string,
   createdAt?: string,
   state: PollState,
   text: string,
-  type: PollType,
   updatedAt?: string,
-  userAnswers: { string: PollChoice[] } // {googleID: PollChoice[]} of answers for MC and upvotes for FR}
+  userAnswers: { string: PollChoice[] } // {googleID: PollChoice[]} of answers
 };
 
 /**
@@ -138,80 +135,20 @@ export default class GroupSocket {
       return;
     }
 
-    switch (poll.type) {
-      case constants.POLL_TYPES.MULTIPLE_CHOICE: // Multiple Choice
-        if (poll.answers[googleID]) { // User selected something before
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.letter && (p.count !== null) && p.letter === poll.answers[googleID][0].letter) { p.count -= 1; }
-          });
-        }
-        // update/add response
-        poll.answers[googleID] = [submittedAnswer];
-        poll.answerChoices.forEach((p: PollResult) => {
-          if (p.letter && (p.count !== null) && p.letter === submittedAnswer.letter) { p.count += 1; }
-        });
-        break;
-      case constants.POLL_TYPES.FREE_RESPONSE: { // Free Response
-        if (poll.answers[googleID]) { // User submitted another FR answer
-          poll.answers[googleID].push(submittedAnswer);
-          poll.upvotes[googleID].push(submittedAnswer);
-        } else { // User submitted first FR answer
-          poll.answers[googleID] = [submittedAnswer];
-          poll.upvotes[googleID] = [submittedAnswer];
-        }
-
-        poll.answerChoices.push({ count: 1, text: submittedAnswer.text, letter: null });
-        break;
-      }
-      default:
-        throw new Error('Unimplemented poll type');
+    if (poll.answers[googleID]) { // User selected something before
+      poll.answerChoices.forEach((p: PollResult) => {
+        if (p.letter && (p.count !== null) && p.letter === poll.answers[googleID][0].letter) { p.count -= 1; }
+      });
     }
+    // update/add response
+    poll.answers[googleID] = [submittedAnswer];
+    poll.answerChoices.forEach((p: PollResult) => {
+      if (p.letter && (p.count !== null) && p.letter === submittedAnswer.letter) { p.count += 1; }
+    });
 
     this.current = poll;
 
     this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
-    if (poll.type === constants.POLL_TYPES.FREE_RESPONSE) {
-      this.nsp.to('members').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-    }
-  }
-
-  _upvoteAnswer(client: IOSocket, googleID: string, upvoteObject: PollChoice): void {
-    const { text } = upvoteObject;
-    const poll = this.current;
-    if (!poll || !text) {
-      // console.log(`Client with googleID ${googleID} tried to answer with no active poll`);
-      return;
-    }
-
-    const currAnswer: ?PollResult = poll.answerChoices.find((p: PollResult) => p.text === text);
-    if (currAnswer) { // User selected a valid answer
-      const userUpvotes = poll.upvotes[googleID];
-      if (userUpvotes) { // User upvoted something before
-        if (userUpvotes.find((p: PollChoice) => p.text === text)) { // unupvote
-          poll.upvotes[googleID] = userUpvotes.filter(p => p.text !== text);
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.count !== null && p.text === text) { p.count -= 1; }
-          });
-        } else { // upvote
-          poll.upvotes[googleID].push({ text });
-          poll.answerChoices.forEach((p: PollResult) => {
-            if (p.count !== null && p.text === text) { p.count += 1; }
-          });
-        }
-      } else { // init array and upvote
-        poll.answerChoices.forEach((p: PollResult) => {
-          if (p.count !== null && p.text === text) { p.count += 1; }
-        });
-        poll.upvotes[googleID] = [{ text }];
-      }
-    }
-
-    this.current = poll;
-
-    this.nsp.to('admins').emit('admin/poll/updates', this._currentPoll(constants.USER_TYPES.ADMIN));
-    if (poll.type === constants.POLL_TYPES.FREE_RESPONSE) {
-      this.nsp.to('members').emit('user/poll/fr/live', this._currentPoll(constants.USER_TYPES.MEMBER));
-    }
   }
 
   // ***************************** User Side ***************************
@@ -222,11 +159,7 @@ export default class GroupSocket {
    * 'server/poll/answer' (PollChoice)
    *  - Client answers current poll
    *  - Adds the answer to answers
-   *  - If poll is free response, then also add to upvotes
    *
-   * 'server/poll/upvote', (PollChoice)
-   *  - Client upvotes an answer or unupvotes if previously upvoted
-   *  - Increases count of answer upvoted or decreases count of answer unupvoted in answerChoices
    * @function
    * @param {IOSocket} client - Client's socket object
    * @param {String} googleID
@@ -234,10 +167,6 @@ export default class GroupSocket {
   _setupUserEvents(client: IOSocket, googleID: string): void {
     client.on('server/poll/answer', (submittedAnswer: PollChoice) => {
       this._answerPoll(client, googleID, submittedAnswer);
-    });
-
-    client.on('server/poll/upvote', (upvoteObject: PollChoice) => {
-      this._upvoteAnswer(client, googleID, upvoteObject);
     });
 
     client.on('disconnect', async () => {
@@ -260,22 +189,15 @@ export default class GroupSocket {
     if (!this.current) return null; // no live poll
     let { correctAnswer } = this.current;
     const {
-      createdAt, updatedAt, answers, answerChoices, state, text, type, upvotes,
+      createdAt, updatedAt, answers, answerChoices, state, text,
     } = this.current;
     const pollID = this.current.id;
 
-    let userAnswers;
-    const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
-    if (isMultipleChoice) {
-      userAnswers = answers;
-    } else {
-      userAnswers = upvotes;
-    }
+    let userAnswers = answers;
     if (!userAnswers) userAnswers = {};
     if (!correctAnswer) correctAnswer = '';
 
     const filteredChoices = userRole === constants.USER_TYPES.ADMIN
-    || !isMultipleChoice
     || state !== constants.POLL_STATES.LIVE
       ? answerChoices
       : answerChoices.map(a => ({ ...a, count: null }));
@@ -288,7 +210,6 @@ export default class GroupSocket {
       correctAnswer,
       state,
       text,
-      type,
       userAnswers,
     };
   }
@@ -305,9 +226,7 @@ export default class GroupSocket {
       correctAnswer: poll.correctAnswer,
       state: constants.POLL_STATES.LIVE,
       text: poll.text,
-      type: poll.type,
       answers: {},
-      upvotes: {},
     };
 
     this.current = newPoll;
@@ -330,11 +249,9 @@ _endPoll = async () => {
     poll.text,
     this.group,
     poll.answerChoices,
-    poll.type,
     poll.correctAnswer,
     poll.answers,
     poll.state,
-    poll.upvotes,
   );
   this.current = { ...createdPoll, id: createdPoll.uuid };
 
@@ -409,7 +326,7 @@ _setupAdminEvents(client: IOSocket): void {
   client.on('server/poll/results', async (pollID: id) => {
     // Update poll to 'shared'
     const sharedPoll = await PollsRepo.updatePollByID(
-      pollID, null, null, null, null, constants.POLL_STATES.SHARED,
+      pollID, null, null, null, constants.POLL_STATES.SHARED,
     );
 
     if (!sharedPoll) {
@@ -418,20 +335,14 @@ _setupAdminEvents(client: IOSocket): void {
     }
 
     const {
-      uuid, createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text, type, upvotes,
+      uuid, createdAt, updatedAt, answers, answerChoices, correctAnswer, state, text,
     } = sharedPoll;
 
-    let userAnswers;
-    const isMultipleChoice = type === constants.POLL_TYPES.MULTIPLE_CHOICE;
-    if (isMultipleChoice) {
-      userAnswers = answers;
-    } else {
-      userAnswers = upvotes;
-    }
+    let userAnswers = answers;
     if (!userAnswers) userAnswers = {};
 
     this.nsp.to('members').emit('user/poll/results', ({
-      id: uuid, createdAt, updatedAt, answerChoices, correctAnswer, state, text, type, userAnswers,
+      id: uuid, createdAt, updatedAt, answerChoices, correctAnswer, state, text, userAnswers,
     } : ClientPoll));
   });
 

--- a/src/models/Draft.js
+++ b/src/models/Draft.js
@@ -25,9 +25,9 @@ class Draft extends Base {
   @Column('character varying')
   text: string = '';
 
-  /** Options of question, empty for FR */
+  /** Options of question */
   @Column('json')
-  options: string[] = undefined;
+  options: string[];
 
   /** User the draft belongs to */
   @ManyToOne(type => User, user => user.drafts)

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -15,7 +15,7 @@ import type { PollState } from '../utils/Constants';
 import constants from '../utils/Constants';
 
 export type PollResult = {|
-  letter: number,
+  index: number,
   text: string,
   count: number,
 |}
@@ -41,7 +41,7 @@ class Poll extends Base {
   /**
    * Choices for the poll
    * @example
-   * let answerChoices = [{letter: 0, text: "Saturn", count: 5}]
+   * let answerChoices = [{index: 0, text: "Saturn", count: 5}]
    */
   @Column('json')
   answerChoices: PollResult[] = undefined;

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -15,14 +15,9 @@ import type { PollState } from '../utils/Constants';
 import constants from '../utils/Constants';
 
 export type PollResult = {|
-  letter: string,
+  letter: number,
   text: string,
-  count: ?number,
-|}
-
-export type PollChoice = {|
-  letter: string,
-  text: string,
+  count: number,
 |}
 
 /**
@@ -46,7 +41,7 @@ class Poll extends Base {
   /**
    * Choices for the poll
    * @example
-   * let answerChoices = [{letter: "A", text: "Saturn", count: 5}]
+   * let answerChoices = [{letter: 0, text: "Saturn", count: 5}]
    */
   @Column('json')
   answerChoices: PollResult[] = undefined;
@@ -54,19 +49,19 @@ class Poll extends Base {
   /**
    * All the answers by students for the poll.
    * @example
-   * let answers = {googleID: [{letter: "A", text: "Saturn"}]}
+   * let answers = {googleID: [0, 1, 3]}
    */
   @Column('json')
-  answers: { string: PollChoice[] } = {};
+  answers: { string: number[] } = {};
 
   /**
    * Correct answer choice.
-   * Empty string if no correct answer chosen.
+   * -1 if no correct answer chosen.
    * @example
-   * let correctAnswer = 'A'
+   * let correctAnswer = 3
   */
-  @Column('character varying')
-  correctAnswer: string = '';
+  @Column('int')
+  correctAnswer: number = -1;
 
   /** The current state of the poll */
   @Column('character varying')

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -10,18 +10,18 @@ import Base from './Base';
 import Group from './Group';
 
 import type { APIPoll } from '../routers/v2/APITypes';
-import type { PollType, PollState } from '../utils/Constants';
+import type { PollState } from '../utils/Constants';
 
 import constants from '../utils/Constants';
 
 export type PollResult = {|
-  letter: ?string,
+  letter: string,
   text: string,
   count: ?number,
 |}
 
 export type PollChoice = {|
-  letter: ?string,
+  letter: string,
   text: string,
 |}
 
@@ -39,10 +39,6 @@ class Poll extends Base {
   @Column('character varying')
   text: string = '';
 
-  /** Type of poll either multipleChoice or freeResponse */
-  @Column('character varying')
-  type: PollType = constants.POLL_TYPES.MULTIPLE_CHOICE;
-
   /** Group the poll belongs to */
   @ManyToOne(type => Group, group => group.polls, { onDelete: 'CASCADE' })
   group: ?Group = null;
@@ -50,34 +46,22 @@ class Poll extends Base {
   /**
    * Choices for the poll
    * @example
-   * let answerChoices_mc = [{letter: "A", text: "Saturn", count: 5}]
-   * let answerChoices_fr = [{text: "Saturn", count: 10}]
+   * let answerChoices = [{letter: "A", text: "Saturn", count: 5}]
    */
   @Column('json')
   answerChoices: PollResult[] = undefined;
 
   /**
    * All the answers by students for the poll.
-   * Letter field is optional and only is returned on MC polls.
    * @example
-   * let answers_MC = {googleID: [{letter: "A", text: "Saturn"}]}
-   * let answers_FR = {googleID: [{text: "Saturn"}, {text: "Mars"}]}
+   * let answers = {googleID: [{letter: "A", text: "Saturn"}]}
    */
   @Column('json')
   answers: { string: PollChoice[] } = {};
 
   /**
-   * All the upvotes by students for the FR poll. Empty if MC.
-   * @example
-   * let upvotes_MC = {}
-   * let upvotes_FR = {googleID: [{text: "Saturn"}, {text: "Mars"}]}
-   */
-  @Column('json')
-  upvotes: { string: PollChoice[] } = {};
-
-  /**
-   * Correct answer choice for MC.
-   * Empty string if FR or no correct answer chosen for MC.
+   * Correct answer choice.
+   * Empty string if no correct answer chosen.
    * @example
    * let correctAnswer = 'A'
   */
@@ -96,7 +80,6 @@ class Poll extends Base {
       correctAnswer: this.correctAnswer,
       state: this.state,
       text: this.text,
-      type: this.type,
       userAnswers: this.answers,
     };
   }

--- a/src/repos/GroupsRepo.js
+++ b/src/repos/GroupsRepo.js
@@ -340,7 +340,6 @@ const getPolls = async (id: string, hideUnsharedResults: ?boolean = true):
     return group.polls.map((poll) => {
       if (
         hideUnsharedResults && poll.state !== constants.POLL_STATES.SHARED
-        && poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
       ) {
         poll.answerChoices = poll.answerChoices.map((choice) => {
           delete choice.count;

--- a/src/repos/PollsRepo.js
+++ b/src/repos/PollsRepo.js
@@ -4,7 +4,7 @@ import Group from '../models/Group';
 import Poll from '../models/Poll';
 import LogUtils from '../utils/LogUtils';
 
-import type { PollChoice, PollResult } from '../models/Poll';
+import type { PollResult } from '../models/Poll';
 import type { PollState } from '../utils/Constants';
 
 const db = (): Repository<Poll> => getRepository(Poll);
@@ -15,8 +15,8 @@ const db = (): Repository<Poll> => getRepository(Poll);
  * @param {string} text - Text of poll
  * @param {Group} group - Group that the poll belongs to
  * @param {PollResult[]} answerChoices - the answer choices for the given poll
- * @param {string} correctAnswer - Correct answer choice
- * @param {string: PollChoice[]} answers - answers given from students
+ * @param {number} correctAnswer - Correct answer choice
+ * @param {string: number[]} answers - answers given from students
  * @param {PollState} state - the current state of the poll
  * @return {Poll} New poll created
  */
@@ -24,14 +24,17 @@ const createPoll = async (
   text: string,
   group: ?Group,
   answerChoices: PollResult[],
-  correctAnswer: ?string,
-  answers: ?{ string: PollChoice[] },
+  correctAnswer: number,
+  answers: ?{ string: number[] },
   state: PollState,
 ): Promise<Poll> => {
   try {
     const poll = new Poll();
     poll.answerChoices = answerChoices;
-    poll.correctAnswer = correctAnswer || '';
+
+    if (correctAnswer !== undefined && correctAnswer !== null) poll.correctAnswer = correctAnswer;
+    else poll.correctAnswer = -1;
+    
     poll.state = state;
     poll.text = text;
     if (group) poll.group = group;
@@ -88,12 +91,12 @@ const deletePollByID = async (id: string) => {
  * @param {string} id - UUID of the poll to update
  * @param {?string} [text] - new text for poll
  * @param {?PollResult[]} answerChoices - the answer choices for the given poll
- * @param {string: PollChoice[]} [answers] - the students answers to the poll
+ * @param {string: number[]} [answers] - the students answers to the poll
  * @param {PollState} [state] - the state of the poll
  * @return {?Poll} Updated poll
  */
 const updatePollByID = async (id: string, text: ?string, answerChoices: ?PollResult[],
-  answers: ?{string: PollChoice[]}, state: ?PollState):
+  answers: ?{string: number[]}, state: ?PollState):
   Promise<?Poll> => {
   try {
     const poll = await db().createQueryBuilder('polls')

--- a/src/repos/PollsRepo.js
+++ b/src/repos/PollsRepo.js
@@ -5,7 +5,7 @@ import Poll from '../models/Poll';
 import LogUtils from '../utils/LogUtils';
 
 import type { PollChoice, PollResult } from '../models/Poll';
-import type { PollType, PollState } from '../utils/Constants';
+import type { PollState } from '../utils/Constants';
 
 const db = (): Repository<Poll> => getRepository(Poll);
 
@@ -15,22 +15,18 @@ const db = (): Repository<Poll> => getRepository(Poll);
  * @param {string} text - Text of poll
  * @param {Group} group - Group that the poll belongs to
  * @param {PollResult[]} answerChoices - the answer choices for the given poll
- * @param {string} type - Type of poll, see Poll class for more info
- * @param {string} correctAnswer - Correct answer choice for MC
+ * @param {string} correctAnswer - Correct answer choice
  * @param {string: PollChoice[]} answers - answers given from students
  * @param {PollState} state - the current state of the poll
- * @param {string: PollChoice[]} upvotes - upvotes given from students
  * @return {Poll} New poll created
  */
 const createPoll = async (
   text: string,
   group: ?Group,
   answerChoices: PollResult[],
-  type: PollType,
   correctAnswer: ?string,
   answers: ?{ string: PollChoice[] },
   state: PollState,
-  upvotes: ?{ string: PollChoice[] },
 ): Promise<Poll> => {
   try {
     const poll = new Poll();
@@ -38,10 +34,8 @@ const createPoll = async (
     poll.correctAnswer = correctAnswer || '';
     poll.state = state;
     poll.text = text;
-    poll.type = type;
     if (group) poll.group = group;
     if (answers) poll.answers = answers;
-    if (upvotes) poll.upvotes = upvotes;
     await db().save(poll);
     return poll;
   } catch (e) {
@@ -50,11 +44,9 @@ const createPoll = async (
       text,
       group,
       answerChoices,
-      type,
       correctAnswer,
       answers,
       state,
-      upvotes,
     });
   }
 };
@@ -97,12 +89,11 @@ const deletePollByID = async (id: string) => {
  * @param {?string} [text] - new text for poll
  * @param {?PollResult[]} answerChoices - the answer choices for the given poll
  * @param {string: PollChoice[]} [answers] - the students answers to the poll
- * @param {string: PollChoice[]} [upvotes] - upvotes from students
  * @param {PollState} [state] - the state of the poll
  * @return {?Poll} Updated poll
  */
 const updatePollByID = async (id: string, text: ?string, answerChoices: ?PollResult[],
-  answers: ?{string: PollChoice[]}, upvotes: ?{string: PollChoice[]}, state: ?PollState):
+  answers: ?{string: PollChoice[]}, state: ?PollState):
   Promise<?Poll> => {
   try {
     const poll = await db().createQueryBuilder('polls')
@@ -113,7 +104,6 @@ const updatePollByID = async (id: string, text: ?string, answerChoices: ?PollRes
     if (text !== undefined && text !== null) poll.text = text;
     if (answerChoices) poll.answerChoices = answerChoices;
     if (answers) poll.answers = answers;
-    if (upvotes) poll.upvotes = upvotes;
     if (state) poll.state = state;
     await db().save(poll);
     return poll;

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -1,5 +1,5 @@
 // @flow
-import type { PollChoice, PollState, PollType } from '../../utils/Constants';
+import type { PollChoice, PollState } from '../../utils/Constants';
 import type { PollResult } from '../../models/Poll';
 
 // *********************** GENERAL RESPONSE TYPES ***********************
@@ -29,7 +29,6 @@ export type APIPoll = {|
   correctAnswer: string,
   state: PollState,
   text: string,
-  type: PollType,
   userAnswers: { string: PollChoice[] },
 |}
 

--- a/src/routers/v2/APITypes.js
+++ b/src/routers/v2/APITypes.js
@@ -1,5 +1,5 @@
 // @flow
-import type { PollChoice, PollState } from '../../utils/Constants';
+import type { PollState } from '../../utils/Constants';
 import type { PollResult } from '../../models/Poll';
 
 // *********************** GENERAL RESPONSE TYPES ***********************
@@ -26,10 +26,10 @@ export type APIPoll = {|
   createdAt: string,
   updatedAt: string,
   answerChoices: PollResult[],
-  correctAnswer: string,
+  correctAnswer: number,
   state: PollState,
   text: string,
-  userAnswers: { string: PollChoice[] },
+  userAnswers: { string: number[] },
 |}
 
 export type APIDraft = {|

--- a/src/routers/v2/Polls/GetGroupPollsRouter.js
+++ b/src/routers/v2/Polls/GetGroupPollsRouter.js
@@ -28,8 +28,7 @@ class GetGroupPollsRouter extends AppDevRouter<Object[]> {
     polls.filter(Boolean).forEach((poll) => {
       // date is in Unix time in seconds
       const date = poll.createdAt;
-      const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-        ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+      const userAnswer = poll.answers[req.user.googleID];
       const answerObject = {};
       answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/Polls/GetPollRouter.js
+++ b/src/routers/v2/Polls/GetPollRouter.js
@@ -28,16 +28,14 @@ class GetPollRouter extends AppDevRouter<APIPoll> {
 
     const isAdmin = await GroupsRepo.isAdmin(group.uuid, req.user);
 
-    if (!isAdmin && poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      && poll.state !== constants.POLL_STATES.SHARED) {
+    if (!isAdmin && poll.state !== constants.POLL_STATES.SHARED) {
       poll.answerChoices = poll.answerChoices.map((answer) => {
         delete answer.count;
         return answer;
       });
     }
 
-    const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+    const userAnswer = poll.answers[req.user.googleID];
     const answerObject: { string: PollChoice[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/Polls/GetPollRouter.js
+++ b/src/routers/v2/Polls/GetPollRouter.js
@@ -7,7 +7,6 @@ import LogUtils from '../../../utils/LogUtils';
 import PollsRepo from '../../../repos/PollsRepo';
 
 import type { APIPoll } from '../APITypes';
-import type { PollChoice } from '../../../utils/Constants';
 
 class GetPollRouter extends AppDevRouter<APIPoll> {
   constructor() {
@@ -36,7 +35,7 @@ class GetPollRouter extends AppDevRouter<APIPoll> {
     }
 
     const userAnswer = poll.answers[req.user.googleID];
-    const answerObject: { string: PollChoice[]} = {};
+    const answerObject: { string: number[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 
     return {

--- a/src/routers/v2/Polls/UpdatePollRouter.js
+++ b/src/routers/v2/Polls/UpdatePollRouter.js
@@ -21,11 +21,11 @@ class UpdatePollRouter extends AppDevRouter<APIPoll> {
   async content(req: Request) {
     const pollID = req.params.id;
     const {
-      text, answerChoices, state, answers, upvotes,
+      text, answerChoices, state, answers,
     } = req.body;
     const { user } = req;
 
-    if (!answerChoices && !text && !state && !answers && !upvotes) {
+    if (!answerChoices && !text && !state && !answers) {
       throw LogUtils.logErr('No fields specified to update');
     }
 
@@ -39,13 +39,12 @@ class UpdatePollRouter extends AppDevRouter<APIPoll> {
     }
 
     const poll = await PollsRepo.updatePollByID(pollID, text,
-      answerChoices, answers, upvotes, state);
+      answerChoices, answers, state);
     if (!poll) {
       throw LogUtils.logErr(`Poll with UUID ${pollID} was not found`);
     }
 
-    const userAnswer = poll.type === constants.POLL_TYPES.MULTIPLE_CHOICE
-      ? poll.answers[req.user.googleID] : poll.upvotes[req.user.googleID];
+    const userAnswer = poll.answers[req.user.googleID];
     const answerObject: { string: PollChoice[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 

--- a/src/routers/v2/Polls/UpdatePollRouter.js
+++ b/src/routers/v2/Polls/UpdatePollRouter.js
@@ -7,7 +7,6 @@ import LogUtils from '../../../utils/LogUtils';
 import PollsRepo from '../../../repos/PollsRepo';
 
 import type { APIPoll } from '../APITypes';
-import type { PollChoice } from '../../../utils/Constants';
 
 class UpdatePollRouter extends AppDevRouter<APIPoll> {
   constructor() {
@@ -45,7 +44,7 @@ class UpdatePollRouter extends AppDevRouter<APIPoll> {
     }
 
     const userAnswer = poll.answers[req.user.googleID];
-    const answerObject: { string: PollChoice[]} = {};
+    const answerObject: { string: number[]} = {};
     answerObject[req.user.googleID] = userAnswer || [];
 
     return {

--- a/src/routers/v2/swagger.json
+++ b/src/routers/v2/swagger.json
@@ -1309,28 +1309,10 @@
           "Socket: to server"
         ],
         "summary": "Answer a poll",
-        "description": "User sends this to answer a multiple choice poll or submit a FR answer",
+        "description": "User sends this to answer a poll",
         "parameters": [
           {
             "name": "submittedAnswer",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/PollChoice"
-            }
-          }
-        ]
-      }
-    },
-    "server/poll/upvote": {
-      "get": {
-        "tags": [
-          "Socket: to server"
-        ],
-        "summary": "Upvote a FR answer",
-        "description": "User sends this to upvote an answer in free response",
-        "parameters": [
-          {
-            "name": "upvotedAnswer",
             "in": "body",
             "schema": {
               "$ref": "#/definitions/PollChoice"
@@ -1413,22 +1395,6 @@
         ],
         "summary": "User receives to display a poll",
         "description": "State should be “live”",
-        "responses": [
-          {
-            "name": "currentPoll",
-            "schema": {
-              "$ref": "#/definitions/Socket - ClientPoll"
-            }
-          }
-        ]
-      }
-    },
-    "user/poll/fr/live": {
-      "get": {
-        "tags": [
-          "Socket: to member"
-        ],
-        "summary": "User receives an updated poll to reflect the current changes (only FR)",
         "responses": [
           {
             "name": "currentPoll",
@@ -1568,7 +1534,7 @@
         },
         "options": {
           "type": "array",
-          "description": "Poll options, empty if FR",
+          "description": "Poll options",
           "items": {
             "type": "string"
           }
@@ -1641,18 +1607,14 @@
           "example": [
             {
               "letter": "A",
-              "text": "MC example",
+              "text": "Example",
               "count": 5
-            },
-            {
-              "text": "FR example",
-              "count": 16
             }
           ]
         },
         "correctAnswer": {
           "type": "string",
-          "description": "Letter of correct answer choice (MC only)",
+          "description": "Letter of correct answer choice",
           "example": "A"
         },
         "createdAt": {
@@ -1674,15 +1636,6 @@
           "description": "Poll question",
           "example": "Which planet is a gas giant?"
         },
-        "type": {
-          "type": "string",
-          "description": "Poll type",
-          "enum": [
-            "multipleChoice",
-            "freeResponse"
-          ],
-          "example": "multipleChoice"
-        },
         "updatedAt": {
           "type": "string",
           "description": "Timestamp (Unix time)",
@@ -1690,7 +1643,7 @@
         },
         "userAnswers": {
           "type": "object",
-          "description": "Mapping of googleID to the choice the user selected if MC, or the choices the user upvoted if FR",
+          "description": "Mapping of googleID to the choice the user selected",
           "properties": {
             "googleID(string)": {
               "type": "array",
@@ -1700,16 +1653,8 @@
               "example": {
                 "googleID1": {
                   "letter": "A",
-                  "text": "selected MC answer"
-                },
-                "googleID2": [
-                  {
-                    "text": "upvoted FR answer1"
-                  },
-                  {
-                    "text": "upvoted FR answer2"
-                  }
-                ]
+                  "text": "selected answer"
+                }
               }
             }
           }
@@ -1732,9 +1677,8 @@
       "properties": {
         "letter": {
           "type": "string",
-          "description": "Letter identifier of answer choice (MC only)",
-          "example": "A",
-          "nullable": true
+          "description": "Letter identifier of answer choice",
+          "example": "A"
         },
         "text": {
           "type": "string",
@@ -1752,14 +1696,13 @@
       "properties": {
         "count": {
           "type": "integer",
-          "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is MC & poll is live",
+          "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is live",
           "nullable": true
         },
         "letter": {
           "type": "string",
-          "description": "Letter identifier of answer choice (MC only)",
-          "example": "A",
-          "nullable": true
+          "description": "Letter identifier of answer choice",
+          "example": "A"
         },
         "text": {
           "type": "string",
@@ -1781,7 +1724,7 @@
         },
         "answerChoices": {
           "type": "array",
-          "description": "All answers for the poll; count is null if user is `member` and MC poll is `live`",
+          "description": "All answers for the poll; count is null if user is `member` and poll is `live`",
           "items": {
             "$ref": "#/definitions/PollResult"
           }
@@ -1789,7 +1732,7 @@
         "correctAnswer": {
           "type": "string",
           "example": "A",
-          "description": "Letter of correct answer choice (MC only)"
+          "description": "Letter of correct answer choice"
         },
         "createdAt": {
           "type": "string",
@@ -1809,14 +1752,6 @@
           "type": "string",
           "description": "Poll question"
         },
-        "type": {
-          "type": "string",
-          "description": "Poll type",
-          "enum": [
-            "multipleChoice",
-            "freeResponse"
-          ]
-        },
         "updatedAt": {
           "type": "string",
           "description": "Timestamp (Unix time)",
@@ -1824,7 +1759,7 @@
         },
         "userAnswers": {
           "type": "object",
-          "description": "Mapping of googleID to user answers for MC and upvotes for FR",
+          "description": "Mapping of googleID to user answers",
           "properties": {
             "googleID(string)": {
               "type": "array",
@@ -1834,16 +1769,8 @@
               "example": {
                 "googleID1": {
                   "letter": "A",
-                  "text": "selected MC answer"
-                },
-                "googleID2": [
-                  {
-                    "text": "upvoted FR answer1"
-                  },
-                  {
-                    "text": "upvoted FR answer2"
-                  }
-                ]
+                  "text": "selected answer"
+                }
               }
             }
           }

--- a/src/routers/v2/swagger.json
+++ b/src/routers/v2/swagger.json
@@ -1315,7 +1315,7 @@
             "name": "submittedAnswer",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/PollChoice"
+              "type": "integer"
             }
           }
         ]
@@ -1606,7 +1606,7 @@
           },
           "example": [
             {
-              "letter": "A",
+              "letter": 0,
               "text": "Example",
               "count": 5
             }
@@ -1614,8 +1614,8 @@
         },
         "correctAnswer": {
           "type": "string",
-          "description": "Letter of correct answer choice",
-          "example": "A"
+          "description": "Letter of correct answer choice, -1 if none",
+          "example": 0
         },
         "createdAt": {
           "type": "string",
@@ -1648,13 +1648,10 @@
             "googleID(string)": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/PollChoice"
+                "type": "integer"
               },
               "example": {
-                "googleID1": {
-                  "letter": "A",
-                  "text": "selected answer"
-                }
+                "googleID1": [3]
               }
             }
           }
@@ -1672,25 +1669,6 @@
         "userAnswers"
       ]
     },
-    "PollChoice": {
-      "type": "object",
-      "properties": {
-        "letter": {
-          "type": "string",
-          "description": "Letter identifier of answer choice",
-          "example": "A"
-        },
-        "text": {
-          "type": "string",
-          "description": "Text of answer choice",
-          "example": "Saturn"
-        }
-      },
-      "required": [
-        "letter",
-        "text"
-      ]
-    },
     "PollResult": {
       "type": "object",
       "properties": {
@@ -1700,9 +1678,9 @@
           "nullable": true
         },
         "letter": {
-          "type": "string",
-          "description": "Letter identifier of answer choice",
-          "example": "A"
+          "type": "integer",
+          "description": "Letter identifier of answer choice as an integer, -1 if none",
+          "example": 2
         },
         "text": {
           "type": "string",
@@ -1731,8 +1709,8 @@
         },
         "correctAnswer": {
           "type": "string",
-          "example": "A",
-          "description": "Letter of correct answer choice"
+          "example": 3,
+          "description": "Letter of correct answer choice, -1 if none"
         },
         "createdAt": {
           "type": "string",
@@ -1764,13 +1742,10 @@
             "googleID(string)": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/PollChoice"
+                "type": "integer"
               },
               "example": {
-                "googleID1": {
-                  "letter": "A",
-                  "text": "selected answer"
-                }
+                "googleID1": [3]
               }
             }
           }

--- a/src/routers/v2/swagger.json
+++ b/src/routers/v2/swagger.json
@@ -1606,7 +1606,7 @@
           },
           "example": [
             {
-              "letter": 0,
+              "index": 0,
               "text": "Example",
               "count": 5
             }
@@ -1614,7 +1614,7 @@
         },
         "correctAnswer": {
           "type": "string",
-          "description": "Letter of correct answer choice, -1 if none",
+          "description": "Index of correct answer choice, -1 if none",
           "example": 0
         },
         "createdAt": {
@@ -1677,9 +1677,9 @@
           "description": "Number of times choice was selected or upvoted<br/>`Null` when user is member & poll is live",
           "nullable": true
         },
-        "letter": {
+        "index": {
           "type": "integer",
-          "description": "Letter identifier of answer choice as an integer, -1 if none",
+          "description": "Index identifier of answer choice as an integer, -1 if none",
           "example": 2
         },
         "text": {
@@ -1690,7 +1690,7 @@
       },
       "required": [
         "count",
-        "letter",
+        "index",
         "text"
       ]
     },
@@ -1710,7 +1710,7 @@
         "correctAnswer": {
           "type": "string",
           "example": 3,
-          "description": "Letter of correct answer choice, -1 if none"
+          "description": "Index of correct answer choice, -1 if none"
         },
         "createdAt": {
           "type": "string",

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -27,16 +27,6 @@ const POLL_STATES = {
 };
 
 /**
-* constants for question types
-* @constant
-* @enum {string}
-*/
-const POLL_TYPES = {
-  MULTIPLE_CHOICE: 'multipleChoice',
-  FREE_RESPONSE: 'freeResponse',
-};
-
-/**
 * constants for user types
 * @constant
 * @enum {string}
@@ -53,11 +43,9 @@ const EXPORT_FORMATS = {
 
 /** Custom types for Poll type */
 export type PollState = 'live' | 'ended' | 'shared'
-export type PollType = 'multipleChoice' | 'freeResponse'
 
 export default {
   POLL_STATES,
-  POLL_TYPES,
   REQUEST_TYPES,
   USER_TYPES,
   EXPORT_FORMATS,

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -197,8 +197,8 @@ test('Get Polls from Group', async () => {
   let polls = await GroupsRepo.getPolls(uuid);
   expect(polls.length).toEqual(0);
 
-  const answerChoices1 = [{ letter: 0, text: 'blue', count: 1 }];
-  const answerChoices1WithoutCounts = [{ letter: 0, text: 'blue' }];
+  const answerChoices1 = [{ index: 0, text: 'blue', count: 1 }];
+  const answerChoices1WithoutCounts = [{ index: 0, text: 'blue' }];
 
   const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, -1, null, 'ended');
   polls = await GroupsRepo.getPolls(uuid);

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -197,10 +197,10 @@ test('Get Polls from Group', async () => {
   let polls = await GroupsRepo.getPolls(uuid);
   expect(polls.length).toEqual(0);
 
-  const answerChoices1 = [{ letter: 'A', text: 'blue', count: 1 }];
-  const answerChoices1WithoutCounts = [{ letter: 'A', text: 'blue' }];
+  const answerChoices1 = [{ letter: 0, text: 'blue', count: 1 }];
+  const answerChoices1WithoutCounts = [{ letter: 0, text: 'blue' }];
 
-  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, '', null, 'ended');
+  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, -1, null, 'ended');
   polls = await GroupsRepo.getPolls(uuid);
   expect(polls.length).toEqual(1);
   expect(polls[0].uuid).toBe(poll.uuid);

--- a/test/repos/group.test.js
+++ b/test/repos/group.test.js
@@ -198,23 +198,17 @@ test('Get Polls from Group', async () => {
   expect(polls.length).toEqual(0);
 
   const answerChoices1 = [{ letter: 'A', text: 'blue', count: 1 }];
-  const answerChoices2 = [{ text: 'blue', count: 0 }, { text: 'red', count: 2 }];
   const answerChoices1WithoutCounts = [{ letter: 'A', text: 'blue' }];
 
-  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, 'multipleChoice', '', null, 'ended');
-  const poll2 = await PollsRepo.createPoll('', group, answerChoices2, 'freeResponse', '', null, 'ended');
+  const poll = await PollsRepo.createPoll('Poll', group, answerChoices1, '', null, 'ended');
   polls = await GroupsRepo.getPolls(uuid);
-  expect(polls.length).toEqual(2);
+  expect(polls.length).toEqual(1);
   expect(polls[0].uuid).toBe(poll.uuid);
-  expect(polls[1].uuid).toBe(poll2.uuid);
   expect(polls[0].answerChoices).toEqual(answerChoices1WithoutCounts);// if member, hide results
-  expect(polls[1].answerChoices).toEqual(answerChoices2);
   polls = await GroupsRepo.getPolls(uuid, false); // if admin, don't hide results
   expect(polls[0].answerChoices).toEqual(answerChoices1);
-  expect(polls[1].answerChoices).toEqual(answerChoices2);
 
   await PollsRepo.deletePollByID(poll.uuid);
-  await PollsRepo.deletePollByID(poll2.uuid);
 });
 
 test('Delete Group', async () => {

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -21,11 +21,11 @@ beforeAll(async () => {
 
 test('Create Poll', async () => {
   const poll = await PollsRepo
-    .createPoll('Poll', group, [], 'A', null, 'shared');
+    .createPoll('Poll', group, [], 0, null, 'shared');
   expect(poll.text).toBe('Poll');
   expect(poll.group.uuid).toBe(group.uuid);
   expect(poll.answerChoices).toEqual([]);
-  expect(poll.correctAnswer).toBe('A');
+  expect(poll.correctAnswer).toBe(0);
   expect(poll.state).toBe('shared');
   expect(poll.answers).toEqual({});
   ({ uuid } = poll);

--- a/test/repos/poll.test.js
+++ b/test/repos/poll.test.js
@@ -4,9 +4,7 @@ import UsersRepo from '../../src/repos/UsersRepo';
 import dbConnection from '../../src/db/DbConnection';
 
 let uuid;
-let uuid2;
 let group;
-let group2;
 let user;
 
 // Connects to db before running tests and does setup
@@ -19,55 +17,30 @@ beforeAll(async () => {
   user = await UsersRepo.createDummyUser('1234');
   group = await GroupsRepo
     .createGroup('Group', GroupsRepo.createCode(), user);
-  group2 = await GroupsRepo
-    .createGroup('Group2', GroupsRepo.createCode(), user);
 });
 
 test('Create Poll', async () => {
   const poll = await PollsRepo
-    .createPoll('Poll', group, [], 'multipleChoice', 'A', null, 'shared', {});
+    .createPoll('Poll', group, [], 'A', null, 'shared');
   expect(poll.text).toBe('Poll');
   expect(poll.group.uuid).toBe(group.uuid);
   expect(poll.answerChoices).toEqual([]);
-  expect(poll.type).toBe('multipleChoice');
   expect(poll.correctAnswer).toBe('A');
   expect(poll.state).toBe('shared');
   expect(poll.answers).toEqual({});
-  expect(poll.upvotes).toEqual({});
   ({ uuid } = poll);
-
-  const poll2 = await PollsRepo.createPoll('', group, [], 'freeResponse', null, {}, 'ended', {});
-  expect(poll2.text).toBe('');
-  expect(poll2.group.uuid).toBe(group.uuid);
-  expect(poll2.answerChoices).toEqual([]);
-  expect(poll2.type).toBe('freeResponse');
-  expect(poll2.correctAnswer).toBe('');
-  expect(poll2.state).toBe('ended');
-  expect(poll2.answers).toEqual({});
-  expect(poll2.upvotes).toEqual({});
-  uuid2 = poll2.uuid;
 });
 
 test('Get Poll', async () => {
   const poll = await PollsRepo.getPollByID(uuid);
   expect(poll.text).toBe('Poll');
   expect(poll.state).toBe('shared');
-  expect(poll.type).toBe('multipleChoice');
-
-  const poll2 = await PollsRepo.getPollByID(uuid2);
-  expect(poll2.text).toBe('');
-  expect(poll2.state).toBe('ended');
-  expect(poll2.type).toBe('freeResponse');
 });
 
 test('Update Poll', async () => {
-  const poll = await PollsRepo.updatePollByID(uuid, 'New Poll', null, null, null, 'ended');
+  const poll = await PollsRepo.updatePollByID(uuid, 'New Poll', null, null, 'ended');
   expect(poll.text).toBe('New Poll');
   expect(poll.state).toBe('ended');
-
-  const poll2 = await PollsRepo.updatePollByID(uuid2, '', null, { user: 'answer' });
-  expect(poll2.text).toBe('');
-  expect(poll2.answers.user).toBe('answer');
 });
 
 test('Get Group from Poll', async () => {
@@ -77,22 +50,19 @@ test('Get Group from Poll', async () => {
 
 test('Get Polls from Group', async () => {
   await PollsRepo
-    .createPoll('Another poll', group, [], 'freeResponse', null, null, 'ended', null);
+    .createPoll('Another poll', group, [], null, null, 'ended');
   const polls = await GroupsRepo.getPolls(group.uuid);
-  expect(polls.length).toBe(3);
+  expect(polls.length).toBe(2);
 });
 
 test('Delete Poll', async () => {
   await PollsRepo.deletePollByID(uuid);
-  await PollsRepo.deletePollByID(uuid2);
   expect(await PollsRepo.getPollByID(uuid)).not.toBeDefined();
-  expect(await PollsRepo.getPollByID(uuid2)).not.toBeDefined();
 });
 
 // Teardown
 afterAll(async () => {
   await GroupsRepo.deleteGroupByID(group.uuid);
-  await GroupsRepo.deleteGroupByID(group2.uuid);
   await UsersRepo.deleteUserByID(user.uuid);
   // eslint-disable-next-line no-console
   console.log('Passed all poll tests');

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -77,8 +77,8 @@ test('Add admins to group', async () => {
   };
   await request(post(`/sessions/${group.id}/admins/`, body,
     adminToken)).then((getres) => {
-    expect(getres.success).toBe(true);
-  });
+      expect(getres.success).toBe(true);
+    });
 });
 
 test('Get admins for group', async () => {
@@ -96,8 +96,8 @@ test('Remove admin from group', async () => {
   };
   await request(put(`/sessions/${group.id}/admins/`, body,
     adminToken)).then((getres) => {
-    expect(getres.success).toBe(true);
-  });
+      expect(getres.success).toBe(true);
+    });
 });
 
 test('Add members to group', async () => {
@@ -106,8 +106,8 @@ test('Add members to group', async () => {
   };
   await request(post(`/sessions/${group.id}/members/`, body,
     adminToken)).then((getres) => {
-    expect(getres.success).toBe(true);
-  });
+      expect(getres.success).toBe(true);
+    });
 });
 
 test('Get groups as member', async () => {
@@ -166,8 +166,8 @@ test('Remove member from group', async () => {
   };
   await request(put(`/sessions/${group.id}/members`, body,
     adminToken)).then((getres) => {
-    expect(getres.success).toBe(true);
-  });
+      expect(getres.success).toBe(true);
+    });
 });
 
 test('Get groups for admin', async () => {
@@ -199,13 +199,13 @@ test('Download csv', async () => {
   let polls: Array<?Poll> = await GroupsRepo.getPolls(group.id);
   console.log(`found ${polls.length} polls`);
   const p1 = await PollsRepo.createPoll(
-    'Poll 1', g, [{ letter: 0, text: 'Saturn' }, { letter: 1, text: 'Mars' }],
+    'Poll 1', g, [{ index: 0, text: 'Saturn' }, { index: 1, text: 'Mars' }],
     0, { u1: [0], u2: [1] }, 'ended',
   );
   polls = await GroupsRepo.getPolls(group.id);
   console.log(`found ${polls.length} polls`);
   const p2 = await PollsRepo.createPoll(
-    'Poll 2', g, [{ letter: 0, text: 'Earth' }, { letter: 1, text: 'Venus' }],
+    'Poll 2', g, [{ index: 0, text: 'Earth' }, { index: 1, text: 'Venus' }],
     1, { u1: [1], u2: [0] }, 'ended',
   );
 
@@ -253,7 +253,7 @@ test('Download csv', async () => {
     .toBe(`NetID,${today.toDateString()}\nu1,2\nu2,2\nu3,0\n`);
 
   const p3 = await PollsRepo.createPoll(
-    'Poll 3', g, [{ letter: 0, text: 'Earth' }, { letter: 1, text: 'Venus' }],
+    'Poll 3', g, [{ index: 0, text: 'Earth' }, { index: 1, text: 'Venus' }],
     1, { u3: [0] }, 'ended',
   );
 

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -77,8 +77,8 @@ test('Add admins to group', async () => {
   };
   await request(post(`/sessions/${group.id}/admins/`, body,
     adminToken)).then((getres) => {
-      expect(getres.success).toBe(true);
-    });
+    expect(getres.success).toBe(true);
+  });
 });
 
 test('Get admins for group', async () => {
@@ -96,8 +96,8 @@ test('Remove admin from group', async () => {
   };
   await request(put(`/sessions/${group.id}/admins/`, body,
     adminToken)).then((getres) => {
-      expect(getres.success).toBe(true);
-    });
+    expect(getres.success).toBe(true);
+  });
 });
 
 test('Add members to group', async () => {
@@ -106,8 +106,8 @@ test('Add members to group', async () => {
   };
   await request(post(`/sessions/${group.id}/members/`, body,
     adminToken)).then((getres) => {
-      expect(getres.success).toBe(true);
-    });
+    expect(getres.success).toBe(true);
+  });
 });
 
 test('Get groups as member', async () => {
@@ -166,8 +166,8 @@ test('Remove member from group', async () => {
   };
   await request(put(`/sessions/${group.id}/members`, body,
     adminToken)).then((getres) => {
-      expect(getres.success).toBe(true);
-    });
+    expect(getres.success).toBe(true);
+  });
 });
 
 test('Get groups for admin', async () => {

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -199,16 +199,14 @@ test('Download csv', async () => {
   let polls: Array<?Poll> = await GroupsRepo.getPolls(group.id);
   console.log(`found ${polls.length} polls`);
   const p1 = await PollsRepo.createPoll(
-    'Poll 1', g, [{ letter: 'A', text: 'Saturn' }, { letter: 'B', text: 'Mars' }],
-    'A',
-    { u1: [{ letter: 'A', text: 'Saturn' }], u2: [{ letter: 'B', text: 'Mars' }] }, 'ended',
+    'Poll 1', g, [{ letter: 0, text: 'Saturn' }, { letter: 1, text: 'Mars' }],
+    0, { u1: [0], u2: [1] }, 'ended',
   );
   polls = await GroupsRepo.getPolls(group.id);
   console.log(`found ${polls.length} polls`);
   const p2 = await PollsRepo.createPoll(
-    'Poll 2', g, [{ letter: 'A', text: 'Earth' }, { letter: 'B', text: 'Venus' }],
-    'B',
-    { u1: [{ letter: 'B', text: 'Venus' }], u2: [{ letter: 'A', text: 'Earth' }] }, 'ended',
+    'Poll 2', g, [{ letter: 0, text: 'Earth' }, { letter: 1, text: 'Venus' }],
+    1, { u1: [1], u2: [0] }, 'ended',
   );
 
   const u1 = await UsersRepo.createUserWithFields('u1', 'u', '1', 'u1@example.com');
@@ -255,9 +253,8 @@ test('Download csv', async () => {
     .toBe(`NetID,${today.toDateString()}\nu1,2\nu2,2\nu3,0\n`);
 
   const p3 = await PollsRepo.createPoll(
-    'Poll 3', g, [{ letter: 'A', text: 'Earth' }, { letter: 'B', text: 'Venus' }],
-    'B',
-    { u3: [{ letter: 'A', text: 'Earth' }] }, 'ended',
+    'Poll 3', g, [{ letter: 0, text: 'Earth' }, { letter: 1, text: 'Venus' }],
+    1, { u3: [0] }, 'ended',
   );
 
   result = await axios.get(`http://localhost:3000/api/v2/sessions/${group.id}/csv`, {

--- a/test/routes/api.group.test.js
+++ b/test/routes/api.group.test.js
@@ -200,14 +200,14 @@ test('Download csv', async () => {
   console.log(`found ${polls.length} polls`);
   const p1 = await PollsRepo.createPoll(
     'Poll 1', g, [{ letter: 'A', text: 'Saturn' }, { letter: 'B', text: 'Mars' }],
-    'multiplechoice', 'A',
+    'A',
     { u1: [{ letter: 'A', text: 'Saturn' }], u2: [{ letter: 'B', text: 'Mars' }] }, 'ended',
   );
   polls = await GroupsRepo.getPolls(group.id);
   console.log(`found ${polls.length} polls`);
   const p2 = await PollsRepo.createPoll(
     'Poll 2', g, [{ letter: 'A', text: 'Earth' }, { letter: 'B', text: 'Venus' }],
-    'multiplechoice', 'B',
+    'B',
     { u1: [{ letter: 'B', text: 'Venus' }], u2: [{ letter: 'A', text: 'Earth' }] }, 'ended',
   );
 
@@ -256,7 +256,7 @@ test('Download csv', async () => {
 
   const p3 = await PollsRepo.createPoll(
     'Poll 3', g, [{ letter: 'A', text: 'Earth' }, { letter: 'B', text: 'Venus' }],
-    'multiplechoice', 'B',
+    'B',
     { u3: [{ letter: 'A', text: 'Earth' }] }, 'ended',
   );
 

--- a/test/routes/api.poll.test.js
+++ b/test/routes/api.poll.test.js
@@ -36,7 +36,7 @@ beforeAll(async () => {
   group = result.data;
 
   poll = await PollsRepo.createPoll('Poll text', await GroupsRepo.getGroupByID(group.id),
-    [{ letter: 0, text: 'Saturn' }], 0, null, 'ended');
+    [{ index: 0, text: 'Saturn' }], 0, null, 'ended');
 
   expect(result.success).toBe(true);
 });
@@ -58,14 +58,14 @@ test('Get polls by group', async () => {
 test('Update poll', async () => {
   const opts = {
     text: 'Updated text',
-    answerChoices: { letter: 0, text: 'Mars' },
+    answerChoices: { index: 0, text: 'Mars' },
     state: 'ended',
   };
   await request(put(`/polls/${poll.uuid}`, opts, token)).then((getres) => {
     expect(getres.success).toBe(true);
     expect(getres.data.text).toBe('Updated text');
     expect(getres.data.state).toBe('ended');
-    expect(getres.data.answerChoices).toMatchObject({ letter: 0, text: 'Mars' });
+    expect(getres.data.answerChoices).toMatchObject({ index: 0, text: 'Mars' });
   });
 });
 

--- a/test/routes/api.poll.test.js
+++ b/test/routes/api.poll.test.js
@@ -36,7 +36,7 @@ beforeAll(async () => {
   group = result.data;
 
   poll = await PollsRepo.createPoll('Poll text', await GroupsRepo.getGroupByID(group.id),
-    [{ letter: 'A', text: 'Saturn' }], 'multipleChoice', 'A', null, 'ended', {});
+    [{ letter: 'A', text: 'Saturn' }], 'A', null, 'ended');
 
   expect(result.success).toBe(true);
 });

--- a/test/routes/api.poll.test.js
+++ b/test/routes/api.poll.test.js
@@ -36,7 +36,7 @@ beforeAll(async () => {
   group = result.data;
 
   poll = await PollsRepo.createPoll('Poll text', await GroupsRepo.getGroupByID(group.id),
-    [{ letter: 'A', text: 'Saturn' }], 'A', null, 'ended');
+    [{ letter: 0, text: 'Saturn' }], 0, null, 'ended');
 
   expect(result.success).toBe(true);
 });
@@ -58,14 +58,14 @@ test('Get polls by group', async () => {
 test('Update poll', async () => {
   const opts = {
     text: 'Updated text',
-    answerChoices: { letter: 'A', text: 'Mars' },
+    answerChoices: { letter: 0, text: 'Mars' },
     state: 'ended',
   };
   await request(put(`/polls/${poll.uuid}`, opts, token)).then((getres) => {
     expect(getres.success).toBe(true);
     expect(getres.data.text).toBe('Updated text');
     expect(getres.data.state).toBe('ended');
-    expect(getres.data.answerChoices).toMatchObject({ letter: 'A', text: 'Mars' });
+    expect(getres.data.answerChoices).toMatchObject({ letter: 0, text: 'Mars' });
   });
 });
 

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -15,16 +15,16 @@ let createdPollID;
 const googleID = 'user1';
 const poll = {
   answerChoices: [{
-    letter: 'A',
+    letter: 0,
     text: 'one',
     count: 0,
   },
   {
-    letter: 'B',
+    letter: 0,
     text: 'two',
     count: 0,
   }],
-  correctAnswer: 'A',
+  correctAnswer: 0,
   state: constants.POLL_STATES.LIVE,
   text: 'How do you spell 1?',
 };
@@ -56,7 +56,7 @@ test('Start poll', () => {
 });
 
 test('Answer poll', () => {
-  const submittedAnswer = { letter: 'B', text: 'two' };
+  const submittedAnswer = 0;
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._answerPoll(mockClient, googleID, submittedAnswer);
 
@@ -64,12 +64,12 @@ test('Answer poll', () => {
   expect(userAnswers.length).toBe(1);
   expect(userAnswers[0]).toBe(submittedAnswer);
 
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.letter === submittedAnswer.letter);
+  const pollChoice = groupSocket.current.answerChoices.find(p => p.letter === submittedAnswer);
   expect(pollChoice.count).toBe(1);
 });
 
 test('Change answer', () => {
-  const submittedAnswer = { letter: 'A', text: 'one' };
+  const submittedAnswer = 0;
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._answerPoll(null, googleID, submittedAnswer);
   
@@ -78,7 +78,7 @@ test('Change answer', () => {
   expect(userAnswers[0]).toBe(submittedAnswer);
 
   groupSocket.current.answerChoices.forEach((pollChoice) => {
-    if (pollChoice.letter === submittedAnswer.letter) {
+    if (pollChoice.letter === submittedAnswer) {
       expect(pollChoice.count).toBe(1);
     } else {
       expect(pollChoice.count).toBe(0);
@@ -94,7 +94,7 @@ test('Get current poll (user)', () => {
   expect(currPoll.correctAnswer).toBe(poll.correctAnswer);
   expect(currPoll.state).toBe(poll.state);
   expect(currPoll.text).toBe(poll.text);
-  expect(currPoll.userAnswers[googleID]).toEqual([{ letter: 'A', text: 'one' }]);
+  expect(currPoll.userAnswers[googleID]).toEqual([0]);
 });
 
 test('Get current poll (admin)', () => {
@@ -105,7 +105,7 @@ test('Get current poll (admin)', () => {
   expect(currPoll.correctAnswer).toBe(poll.correctAnswer);
   expect(currPoll.state).toBe(poll.state);
   expect(currPoll.text).toBe(poll.text);
-  expect(currPoll.userAnswers[googleID]).toEqual([{ letter: 'A', text: 'one' }]);
+  expect(currPoll.userAnswers[googleID]).toEqual([0]);
 });
 
 test('Delete live poll', () => {

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -10,11 +10,9 @@ import GroupsRepo from '../src/repos/GroupsRepo';
 let groupSocket;
 let group;
 let mockClient;
-let createdPollID;
+// let createdPollID;
 
 const googleID = 'user1';
-const googleID2 = 'user2';
-const googleID3 = 'user3';
 const poll = {
   answerChoices: [{
     letter: 'A',
@@ -29,23 +27,6 @@ const poll = {
   correctAnswer: 'A',
   state: constants.POLL_STATES.LIVE,
   text: 'How do you spell 1?',
-  type: constants.POLL_TYPES.MULTIPLE_CHOICE,
-};
-const pollFR = {
-  answerChoices: [{
-    letter: null,
-    text: 'GET',
-    count: 0,
-  },
-  {
-    letter: null,
-    text: 'POST',
-    count: 1,
-  }],
-  correctAnswer: '',
-  state: constants.POLL_STATES.LIVE,
-  text: 'What are HTTP request types?',
-  type: constants.POLL_TYPES.FREE_RESPONSE,
 };
 
 // Connects to db before running tests and does setup
@@ -62,7 +43,7 @@ beforeAll(async () => {
   mockClient = groupSocket.nsp.to('members');
 });
 
-test('Start poll (MC)', () => {
+test('Start poll', () => {
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._startPoll(poll);
   expect(groupSocket.current).toMatchObject({
@@ -70,13 +51,11 @@ test('Start poll (MC)', () => {
     correctAnswer: poll.correctAnswer,
     state: poll.state,
     text: poll.text,
-    type: poll.type,
     answers: {},
-    upvotes: {},
   });
 });
 
-test('Answer poll (MC)', () => {
+test('Answer poll', () => {
   const submittedAnswer = { letter: 'B', text: 'two' };
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._answerPoll(mockClient, googleID, submittedAnswer);
@@ -89,7 +68,7 @@ test('Answer poll (MC)', () => {
   expect(pollChoice.count).toBe(1);
 });
 
-test('Change answer (MC)', () => {
+test('Change answer', () => {
   const submittedAnswer = { letter: 'A', text: 'one' };
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._answerPoll(null, googleID, submittedAnswer);
@@ -107,7 +86,7 @@ test('Change answer (MC)', () => {
   });
 });
 
-test('Get current MC poll (user)', () => {
+test('Get current poll (user)', () => {
   // eslint-disable-next-line no-underscore-dangle
   const currPoll = groupSocket._currentPoll('member');
 
@@ -115,11 +94,10 @@ test('Get current MC poll (user)', () => {
   expect(currPoll.correctAnswer).toBe(poll.correctAnswer);
   expect(currPoll.state).toBe(poll.state);
   expect(currPoll.text).toBe(poll.text);
-  expect(currPoll.type).toBe(poll.type);
   expect(currPoll.userAnswers[googleID]).toEqual([{ letter: 'A', text: 'one' }]);
 });
 
-test('Get current MC poll (admin)', () => {
+test('Get current poll (admin)', () => {
   // eslint-disable-next-line no-underscore-dangle
   const currPoll = groupSocket._currentPoll('admin');
 
@@ -127,141 +105,22 @@ test('Get current MC poll (admin)', () => {
   expect(currPoll.correctAnswer).toBe(poll.correctAnswer);
   expect(currPoll.state).toBe(poll.state);
   expect(currPoll.text).toBe(poll.text);
-  expect(currPoll.type).toBe(poll.type);
   expect(currPoll.userAnswers[googleID]).toEqual([{ letter: 'A', text: 'one' }]);
 });
 
-test('End live poll', () => {
+test('Delete live poll', () => {
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._deleteLivePoll();
   expect(groupSocket.current).toBeNull();
 });
 
-test('Start poll (FR)', () => {
-  const clientPoll = {
-    ...pollFR,
-    answerChoices: [],
-  };
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._startPoll(clientPoll);
-  expect(groupSocket.current).toMatchObject({
-    answerChoices: clientPoll.answerChoices,
-    correctAnswer: clientPoll.correctAnswer,
-    state: clientPoll.state,
-    text: clientPoll.text,
-    type: clientPoll.type,
-    answers: {},
-    upvotes: {},
-  });
-});
+// test('Delete poll', async () => {
+//   // eslint-disable-next-line no-underscore-dangle
+//   await groupSocket._deletePoll(createdPollID);
 
-test('Answer poll (FR)', () => {
-  const submittedAnswer = { text: 'GET' };
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._answerPoll(mockClient, googleID, submittedAnswer);
-
-  const userAnswers = groupSocket.current.answers[googleID];
-  const userUpvotes = groupSocket.current.upvotes[googleID];
-  expect(userAnswers.length).toBe(1);
-  expect(userAnswers[0]).toEqual(submittedAnswer);
-  expect(userUpvotes.length).toBe(1);
-  expect(userUpvotes[0]).toEqual(submittedAnswer);
-
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.text === submittedAnswer.text);
-  expect(pollChoice.count).toBe(1);
-  expect(pollChoice.letter).toBeNull();
-});
-
-test('Unupvote own answer (FR)', () => {
-  const upvotedAnswer = { text: 'GET' };
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._upvoteAnswer(mockClient, googleID, upvotedAnswer);
-
-  const userAnswers = groupSocket.current.answers[googleID];
-  const userUpvotes = groupSocket.current.upvotes[googleID];
-  expect(userAnswers.length).toBe(1);
-  expect(userAnswers[0]).toEqual(upvotedAnswer);
-  expect(userUpvotes.length).toBe(0);
-
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.text === upvotedAnswer.text);
-  expect(pollChoice.count).toBe(0);
-});
-
-test('Upvote poll (FR)', () => {
-  const submittedAnswer = { text: 'POST' };
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._answerPoll(mockClient, googleID, submittedAnswer);
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._upvoteAnswer(mockClient, googleID2, submittedAnswer);
-
-  const userAnswers = groupSocket.current.answers[googleID2];
-  const userUpvotes = groupSocket.current.upvotes[googleID2];
-  expect(userAnswers).toBeUndefined();
-  expect(userUpvotes.length).toBe(1);
-  expect(userUpvotes[0]).toEqual(submittedAnswer);
-
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.text === submittedAnswer.text);
-  expect(pollChoice.count).toBe(2);
-  expect(pollChoice.letter).toBeNull();
-});
-
-test('Unupvote answer (FR)', () => {
-  const upvotedAnswer = { text: 'POST' };
-  // eslint-disable-next-line no-underscore-dangle
-  groupSocket._upvoteAnswer(mockClient, googleID2, upvotedAnswer);
-
-  const userAnswers = groupSocket.current.answers[googleID2];
-  const userUpvotes = groupSocket.current.upvotes[googleID2];
-  expect(userAnswers).toBeUndefined();
-  expect(userUpvotes.length).toBe(0);
-
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.text === upvotedAnswer.text);
-  expect(pollChoice.count).toBe(1);
-});
-
-test('Get current FR poll (admin/member)', () => {
-  // eslint-disable-next-line no-underscore-dangle
-  const currPollAdmin = groupSocket._currentPoll('admin');
-  // eslint-disable-next-line no-underscore-dangle
-  const currPoll = groupSocket._currentPoll('member');
-
-  expect(currPollAdmin).toEqual(currPoll);
-
-  expect(currPoll.answerChoices).toEqual(pollFR.answerChoices);
-  expect(currPoll.correctAnswer).toBe(pollFR.correctAnswer);
-  expect(currPoll.state).toBe(pollFR.state);
-  expect(currPoll.text).toBe(pollFR.text);
-  expect(currPoll.type).toBe(pollFR.type);
-  expect(currPoll.userAnswers[googleID]).toEqual([{ text: 'POST' }]);
-});
-
-test('End poll (FR)', async () => {
-  const socketPoll = groupSocket.current;
-  // eslint-disable-next-line no-underscore-dangle
-  await groupSocket._endPoll();
-
-  expect(groupSocket.current).toBeNull();
-
-  const polls = await GroupsRepo.getPolls(group.uuid);
-  const createdPoll = polls[0];
-  createdPollID = createdPoll.uuid;
-
-  expect(createdPoll.text).toBe(pollFR.text);
-  expect(createdPoll.type).toBe(pollFR.type);
-  expect(createdPoll.correctAnswer).toBe(pollFR.correctAnswer);
-  expect(createdPoll.state).toBe(constants.POLL_STATES.ENDED);
-  expect(createdPoll.answerChoices).toEqual(pollFR.answerChoices);
-  expect(createdPoll.answers).toEqual(socketPoll.answers);
-  expect(createdPoll.upvotes).toEqual(socketPoll.upvotes);
-});
-
-test('Delete poll', async () => {
-  // eslint-disable-next-line no-underscore-dangle
-  await groupSocket._deletePoll(createdPollID);
-
-  const polls = await GroupsRepo.getPolls(group.uuid);
-  expect(polls.length).toBe(0);
-});
+//   const polls = await GroupsRepo.getPolls(group.uuid);
+//   expect(polls.length).toBe(0);
+// });
 
 // Teardown
 afterAll(async () => {

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -15,12 +15,12 @@ let createdPollID;
 const googleID = 'user1';
 const poll = {
   answerChoices: [{
-    letter: 0,
+    index: 0,
     text: 'one',
     count: 0,
   },
   {
-    letter: 0,
+    index: 0,
     text: 'two',
     count: 0,
   }],
@@ -64,7 +64,7 @@ test('Answer poll', () => {
   expect(userAnswers.length).toBe(1);
   expect(userAnswers[0]).toBe(submittedAnswer);
 
-  const pollChoice = groupSocket.current.answerChoices.find(p => p.letter === submittedAnswer);
+  const pollChoice = groupSocket.current.answerChoices.find(p => p.index === submittedAnswer);
   expect(pollChoice.count).toBe(1);
 });
 
@@ -72,13 +72,13 @@ test('Change answer', () => {
   const submittedAnswer = 0;
   // eslint-disable-next-line no-underscore-dangle
   groupSocket._answerPoll(null, googleID, submittedAnswer);
-  
+
   const userAnswers = groupSocket.current.answers[googleID];
   expect(userAnswers.length).toBe(1);
   expect(userAnswers[0]).toBe(submittedAnswer);
 
   groupSocket.current.answerChoices.forEach((pollChoice) => {
-    if (pollChoice.letter === submittedAnswer) {
+    if (pollChoice.index === submittedAnswer) {
       expect(pollChoice.count).toBe(1);
     } else {
       expect(pollChoice.count).toBe(0);

--- a/test/socket.test.js
+++ b/test/socket.test.js
@@ -10,7 +10,7 @@ import GroupsRepo from '../src/repos/GroupsRepo';
 let groupSocket;
 let group;
 let mockClient;
-// let createdPollID;
+let createdPollID;
 
 const googleID = 'user1';
 const poll = {
@@ -114,13 +114,37 @@ test('Delete live poll', () => {
   expect(groupSocket.current).toBeNull();
 });
 
-// test('Delete poll', async () => {
-//   // eslint-disable-next-line no-underscore-dangle
-//   await groupSocket._deletePoll(createdPollID);
+test('Start poll 2', () => {
+  // eslint-disable-next-line no-underscore-dangle
+  groupSocket._startPoll(poll);
+  expect(groupSocket.current).toMatchObject({
+    answerChoices: poll.answerChoices,
+    correctAnswer: poll.correctAnswer,
+    state: poll.state,
+    text: poll.text,
+    answers: {},
+  });
+});
 
-//   const polls = await GroupsRepo.getPolls(group.uuid);
-//   expect(polls.length).toBe(0);
-// });
+test('End poll 2', async () => {
+  // eslint-disable-next-line no-underscore-dangle
+  await groupSocket._endPoll();
+
+  expect(groupSocket.current).toBeNull();
+
+  const polls = await GroupsRepo.getPolls(group.uuid);
+  const createdPoll = polls[0];
+  expect(createdPoll.state).toBe(constants.POLL_STATES.ENDED);
+  createdPollID = createdPoll.uuid;
+});
+
+test('Delete poll', async () => {
+  // eslint-disable-next-line no-underscore-dangle
+  await groupSocket._deletePoll(createdPollID);
+
+  const polls = await GroupsRepo.getPolls(group.uuid);
+  expect(polls.length).toBe(0);
+});
 
 // Teardown
 afterAll(async () => {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
As a part of downsizing, various free-response related fields were removed.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
the field `letter` is renamed to `index` because of the change from `string` to `int`

**API Poll**
`type` - removed

**Draft**
`options: string[]` - will no longer be empty for FR

**Poll (Types)**
`PollType` - type removed
`PollResult` - `index` is no longer optional
`PollChoice` - `index` is no longer optional

**Poll (Fields)**
`upvotes` - removed
`answerChoices: PollResult[]` - see `PollResult`
`answers: { googleID : PollChoice[] }`  - see `PollChoice`
`correctAnswer` - no behavioral changes, just won’t be empty string if FR

**SocketPoll**
`type` - removed
`upvotes` - removed
`answers` - will be `{ googleID : PollChoice }` instead of `PollChoice[]`

**ClientPoll**
`type` - removed
`upvotes` - removed

**Socket**
`user/poll/fr/live` - event removed
`server/poll/upvote` - event removed

### answerChoices changes

**Poll**
`answers` is now 

    { string: int[] } 

representing 

    {
      googleID1: [0, 1, 3],
      googleID2: [2]
    }

`answerChoices` is now 

    [
      {
        index: int,
        text: string,
        count: int
      }
    ]

e.x.

    [{
      letter: 0,
      text: "Peanuts",
      count: 5
    }]

`correctAnswer` is an `int` and is `-1` if no correct answer for poll

`PollChoice` is removed


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Tested locally - tests pass. Frontend has done preliminary testing on this branch but we'll keep an eye out. Let me know if you spot an inconsistency with the above information and the code changes! 