### PR TITLE
Deploy different dev and prod docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 - postgresql
 addons:
   postgresql: '9.6'
-  ssh_known_hosts: 
+  ssh_known_hosts:
   - pollo-backend.cornellappdev.com
   - pollo-dev.cornellappdev.com
 before_install:
@@ -18,10 +18,12 @@ jobs:
     env:
     - NODE_IMAGE=pollo-dev
     - DOMAIN=pollo-dev.cornellappdev.com
+    - TARGET=dev
   - if: branch = release
     env:
     - NODE_IMAGE=pollo
     - DOMAIN=pollo-backend.cornellappdev.com
+    - TARGET=prod
 script:
 - npm run start &
 - sleep 10; npm run test

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,4 +8,4 @@ COPY . .
 RUN npm install
 EXPOSE 3000
 
-CMD npm run prod 
+CMD npm start

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,11 @@
+FROM node:10
+
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm install
+EXPOSE 3000
+
+CMD npm run prod

--- a/docker_push
+++ b/docker_push
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker build -t cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT" --no-cache .
-docker push cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"
+docker build -t cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"-"$TARGET" --no-cache -f Dockerfile."$TARGET" .
+docker push cornellappdev/"$NODE_IMAGE":"$TRAVIS_COMMIT"-"$TARGET"
 openssl aes-256-cbc -K $encrypted_b9db1102fcfa_key -iv $encrypted_b9db1102fcfa_iv -in server.pem.enc -out server.pem -d
 chmod 600 server.pem
-ssh -i server.pem appdev@"$DOMAIN" "cd docker-compose; export IMAGE_TAG='$TRAVIS_COMMIT'; 
+ssh -i server.pem appdev@"$DOMAIN" "cd docker-compose; export IMAGE_TAG='$TRAVIS_COMMIT-$TARGET';
     docker stack deploy --compose-file docker-compose.yml the-stack"


### PR DESCRIPTION
## Overview

Currently, our dev server ran in production mode, meaning that dev only features are not possible. This pr adds separate `Dockerfile.dev` and `Dockerfile.prod` files to allow different features and restrictions.


## Changes Made

Created two dockerfiles and updated travis to deploy correctly.


## Test Coverage

There was no really good way to test the travis portion of this without merging it and actually attempting to deploy. Unfortunately, my docker also decided that appropriate behavior was deleting important system files, so it would be appreciated if someone else oculd verify that these images build and run successfully.
